### PR TITLE
feat: add pr module with link to current branch's GitHub PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ Inside the `left` and `right` arrays, you can add the following sections to for 
 * **cargo** - show a crab icon if a `Cargo.toml` file is present in the current dir
 * **git** - show the current git branch and status of the repo (modified, staged, and untracked files, plus git remote
   ahead/behind stats)
-* **pr** - show a clickable link to the open GitHub PR for the current branch (via the [`gh`](https://cli.github.com)
-  CLI), if one exists. The lookup runs in the background and is cached, so it never blocks the prompt - the link
-  appears on a subsequent prompt once the result is ready. Skipped entirely on `develop`, `main`, and `master`.
+* **pr** - show a clickable link to the GitHub PR for the current branch (via the [`gh`](https://cli.github.com)
+  CLI), if one exists. The segment colour reflects the PR state (draft, open, merged, closed). The lookup runs in the
+  background and is cached, so it never blocks the prompt - the link appears on a subsequent prompt once the result is
+  ready. Skipped entirely on `develop`, `main`, and `master`.
 
 There are also three ways to modify the layout:
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Inside the `left` and `right` arrays, you can add the following sections to for 
 * **cargo** - show a crab icon if a `Cargo.toml` file is present in the current dir
 * **git** - show the current git branch and status of the repo (modified, staged, and untracked files, plus git remote
   ahead/behind stats)
+* **pr** - show a clickable link to the open GitHub PR for the current branch (via the [`gh`](https://cli.github.com)
+  CLI), if one exists. The lookup runs in the background and is cached, so it never blocks the prompt - the link
+  appears on a subsequent prompt once the result is ready. Skipped entirely on `develop`, `main`, and `master`.
 
 There are also three ways to modify the layout:
 

--- a/example_theme.json
+++ b/example_theme.json
@@ -36,8 +36,14 @@
       "dirty_fg": "white"
     },
     "pr": {
-      "bg": "nice_purple",
-      "fg": "white",
+      "draft_bg": "mid_grey",
+      "draft_fg": "white",
+      "open_bg": "forest_green",
+      "open_fg": "white",
+      "merged_bg": "nice_purple",
+      "merged_fg": "white",
+      "closed_bg": "mid_red",
+      "closed_fg": "white",
       "icon": ""
     },
     "readonly": {

--- a/example_theme.json
+++ b/example_theme.json
@@ -35,6 +35,11 @@
       "dirty_bg": "bright_orange",
       "dirty_fg": "white"
     },
+    "pr": {
+      "bg": "nice_purple",
+      "fg": "white",
+      "icon": ""
+    },
     "readonly": {
       "fg": 254,
       "bg": 124

--- a/src/bin/powerline.rs
+++ b/src/bin/powerline.rs
@@ -13,6 +13,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use thiserror::Error;
 
 use powerline_rs::config::{Config, TerminalRuntimeMetadata};
+use powerline_rs::modules::refresh_pr;
 use powerline_rs::terminal::{Shell, SHELL};
 use powerline_rs::themes::{CustomTheme, RainbowTheme, SimpleTheme};
 use powerline_rs::Powerline;
@@ -94,6 +95,10 @@ enum PowerlineArgs {
     ShowRight(ShowArgs),
     Install(InstallArgs),
     Config,
+    /// Internal: refresh the cached PR lookup for a branch. Spawned in the
+    /// background by the `pr` module - not intended to be called by hand.
+    #[command(hide = true)]
+    RefreshPr(RefreshPrArgs),
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -122,6 +127,16 @@ struct ShowArgs {
     status: String,
     #[arg(long)]
     config: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct RefreshPrArgs {
+    #[arg(long)]
+    branch: String,
+    #[arg(long)]
+    repo_dir: PathBuf,
+    #[arg(long)]
+    cache: PathBuf,
 }
 
 #[derive(Debug, Args)]
@@ -163,6 +178,7 @@ fn main() {
         PowerlineArgs::ShowRight(args) => show(args, true),
         PowerlineArgs::Install(args) => install(args),
         PowerlineArgs::Config => open_config(),
+        PowerlineArgs::RefreshPr(args) => refresh_pr(&args.branch, &args.repo_dir, &args.cache),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub enum LineSegment {
     },
     ReadOnly,
     Git,
+    Pr,
     PythonEnv,
     Nvm,
     Sdkman,

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -5,6 +5,7 @@ mod cwd;
 mod exit_code;
 mod git;
 mod host;
+mod pr;
 mod readonly;
 mod user;
 
@@ -25,6 +26,7 @@ pub use exit_code::{ExitCode, ExitCodeScheme};
 pub use git::{Git, GitScheme};
 pub use host::{Host, HostScheme};
 pub use nvm::{Nvm, NvmScheme};
+pub use pr::{refresh_pr, Pr, PrScheme};
 pub use python_env::{PythonEnv, PythonEnvScheme};
 pub use readonly::{ReadOnly, ReadOnlyScheme};
 pub use sdkman_java::{SdkmanJava, SdkmanScheme};

--- a/src/modules/pr.rs
+++ b/src/modules/pr.rs
@@ -31,10 +31,28 @@ pub struct Pr<S> {
 }
 
 pub trait PrScheme: DefaultColors {
-    fn pr_fg() -> Color {
+    fn pr_draft_fg() -> Color {
         Self::default_fg()
     }
-    fn pr_bg() -> Color {
+    fn pr_draft_bg() -> Color {
+        Self::default_bg()
+    }
+    fn pr_open_fg() -> Color {
+        Self::default_fg()
+    }
+    fn pr_open_bg() -> Color {
+        Self::default_bg()
+    }
+    fn pr_merged_fg() -> Color {
+        Self::default_fg()
+    }
+    fn pr_merged_bg() -> Color {
+        Self::default_bg()
+    }
+    fn pr_closed_fg() -> Color {
+        Self::default_fg()
+    }
+    fn pr_closed_bg() -> Color {
         Self::default_bg()
     }
     fn pr_icon() -> &'static str {
@@ -56,10 +74,32 @@ impl<S: PrScheme> Pr<S> {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum PrState {
+    Draft,
+    Open,
+    Merged,
+    Closed,
+}
+
+impl PrState {
+    /// Picks the (fg, bg) colors for this state from the active scheme.
+    fn style<S: PrScheme>(self) -> (Color, Color) {
+        match self {
+            PrState::Draft => (S::pr_draft_fg(), S::pr_draft_bg()),
+            PrState::Open => (S::pr_open_fg(), S::pr_open_bg()),
+            PrState::Merged => (S::pr_merged_fg(), S::pr_merged_bg()),
+            PrState::Closed => (S::pr_closed_fg(), S::pr_closed_bg()),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct PrInfo {
     number: u64,
     url: String,
+    state: PrState,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -97,7 +137,8 @@ impl<S: PrScheme> Module for Pr<S> {
         // Render whatever we have right now (possibly slightly stale).
         if let Some(PrCache { pr: Some(pr), .. }) = cache {
             let label = format!("{} #{}", S::pr_icon(), pr.number);
-            powerline.add_hyperlink_segment(&label, &pr.url, Style::simple(S::pr_fg(), S::pr_bg()));
+            let (fg, bg) = pr.state.style::<S>();
+            powerline.add_hyperlink_segment(&label, &pr.url, Style::simple(fg, bg));
         }
     }
 }
@@ -214,7 +255,7 @@ pub fn refresh_pr(branch: &str, repo_dir: &Path, cache_path: &Path) {
 fn fetch_pr(branch: &str, repo_dir: &Path) -> Option<PrInfo> {
     let output = Command::new("gh")
         .current_dir(repo_dir)
-        .args(["pr", "view", branch, "--json", "number,url"])
+        .args(["pr", "view", branch, "--json", "number,url,state,isDraft"])
         .output()
         .ok()?;
 
@@ -223,7 +264,34 @@ fn fetch_pr(branch: &str, repo_dir: &Path) -> Option<PrInfo> {
         return None;
     }
 
-    serde_json::from_slice(&output.stdout).ok()
+    let gh: GhPr = serde_json::from_slice(&output.stdout).ok()?;
+
+    // A draft PR is reported as OPEN with `isDraft: true`, so check that first.
+    let state = if gh.is_draft {
+        PrState::Draft
+    } else {
+        match gh.state.as_str() {
+            "MERGED" => PrState::Merged,
+            "CLOSED" => PrState::Closed,
+            _ => PrState::Open,
+        }
+    };
+
+    Some(PrInfo {
+        number: gh.number,
+        url: gh.url,
+        state,
+    })
+}
+
+/// Shape of the `gh pr view --json ...` response we care about.
+#[derive(Deserialize)]
+struct GhPr {
+    number: u64,
+    url: String,
+    state: String,
+    #[serde(rename = "isDraft")]
+    is_draft: bool,
 }
 
 fn write_cache(path: &Path, cache: &PrCache) {

--- a/src/modules/pr.rs
+++ b/src/modules/pr.rs
@@ -1,0 +1,242 @@
+use std::collections::hash_map::DefaultHasher;
+use std::env;
+use std::fs::{self, File};
+use std::hash::{Hash, Hasher};
+use std::io::Write as _;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::colors::Color;
+use crate::themes::DefaultColors;
+use crate::{Powerline, Style};
+
+use super::Module;
+
+/// How long a cached lookup stays fresh. Prompts rendered within this window
+/// reuse the cache and never touch the network.
+const CACHE_TTL: Duration = Duration::from_secs(60);
+/// Debounce window for the background refresher, so several prompts rendered in
+/// quick succession don't each spawn their own `gh` process.
+const REFRESH_DEBOUNCE: Duration = Duration::from_secs(20);
+
+/// Branches that never have a PR of their own - skip all work for these.
+const SKIP_BRANCHES: &[&str] = &["develop", "main", "master", "HEAD"];
+
+pub struct Pr<S> {
+    scheme: PhantomData<S>,
+}
+
+pub trait PrScheme: DefaultColors {
+    fn pr_fg() -> Color {
+        Self::default_fg()
+    }
+    fn pr_bg() -> Color {
+        Self::default_bg()
+    }
+    fn pr_icon() -> &'static str {
+        "\u{ea64}" // nf-cod-git_pull_request
+    }
+}
+
+impl<S: PrScheme> Default for Pr<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S: PrScheme> Pr<S> {
+    pub fn new() -> Pr<S> {
+        Pr {
+            scheme: PhantomData,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct PrInfo {
+    number: u64,
+    url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PrCache {
+    branch: String,
+    /// `None` means "looked up, but no PR exists for this branch" - cached so we
+    /// don't re-query on every prompt.
+    pr: Option<PrInfo>,
+    fetched_at: u64,
+}
+
+impl<S: PrScheme> Module for Pr<S> {
+    fn append_segments(&mut self, powerline: &mut Powerline) {
+        let Some((branch, repo_root)) = current_branch_and_root() else {
+            return;
+        };
+        if SKIP_BRANCHES.contains(&branch.as_str()) {
+            return;
+        }
+
+        // Without a cache directory we'd have to fetch synchronously, which
+        // could block the prompt on a network request - so bail instead.
+        let Some(cache_path) = cache_path_for(&repo_root, &branch) else {
+            return;
+        };
+
+        let cache = read_cache(&cache_path).filter(|c| c.branch == branch);
+
+        // Refresh in the background when the cache is missing or stale. This
+        // never blocks rendering - the result is picked up by a later prompt.
+        if cache.as_ref().is_none_or(|c| is_stale(c.fetched_at)) {
+            spawn_refresh(&branch, &repo_root, &cache_path);
+        }
+
+        // Render whatever we have right now (possibly slightly stale).
+        if let Some(PrCache { pr: Some(pr), .. }) = cache {
+            let label = format!("{} #{}", S::pr_icon(), pr.number);
+            powerline.add_hyperlink_segment(&label, &pr.url, Style::simple(S::pr_fg(), S::pr_bg()));
+        }
+    }
+}
+
+/// Resolves the current branch name and repository root in a single, fast,
+/// network-free git invocation. Returns `None` outside a git repository.
+fn current_branch_and_root() -> Option<(String, PathBuf)> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD", "--show-toplevel"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8(output.stdout).ok()?;
+    let mut lines = text.lines();
+    let branch = lines.next()?.trim().to_string();
+    let root = lines.next()?.trim();
+
+    if branch.is_empty() || root.is_empty() {
+        return None;
+    }
+
+    Some((branch, PathBuf::from(root)))
+}
+
+fn cache_path_for(repo_root: &Path, branch: &str) -> Option<PathBuf> {
+    let base = env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))?;
+
+    let mut hasher = DefaultHasher::new();
+    repo_root.hash(&mut hasher);
+    branch.hash(&mut hasher);
+
+    Some(
+        base.join("powerline-rs")
+            .join(format!("pr-{:016x}.json", hasher.finish())),
+    )
+}
+
+fn read_cache(path: &Path) -> Option<PrCache> {
+    serde_json::from_reader(File::open(path).ok()?).ok()
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn is_stale(fetched_at: u64) -> bool {
+    now_secs().saturating_sub(fetched_at) >= CACHE_TTL.as_secs()
+}
+
+/// True if a refresh was kicked off recently enough that we should let it
+/// finish rather than spawning another one.
+fn refresh_in_flight(lock_path: &Path) -> bool {
+    fs::metadata(lock_path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|elapsed| elapsed < REFRESH_DEBOUNCE)
+}
+
+/// Spawns a detached process to refresh the cache. The child's stdio is
+/// redirected to null so the shell's command substitution doesn't block
+/// waiting on the inherited pipe.
+fn spawn_refresh(branch: &str, repo_root: &Path, cache_path: &Path) {
+    let lock_path = cache_path.with_extension("lock");
+    if refresh_in_flight(&lock_path) {
+        return;
+    }
+
+    if let Some(parent) = cache_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    // Touch the lock up front to debounce concurrent prompts.
+    let _ = File::create(&lock_path);
+
+    let Ok(exe) = env::current_exe() else {
+        return;
+    };
+
+    let _ = Command::new(exe)
+        .arg("refresh-pr")
+        .args(["--branch", branch])
+        .arg("--repo-dir")
+        .arg(repo_root)
+        .arg("--cache")
+        .arg(cache_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+}
+
+/// Performs the blocking `gh` lookup and writes the cache. Invoked by the
+/// hidden `refresh-pr` subcommand from the detached process spawned above.
+pub fn refresh_pr(branch: &str, repo_dir: &Path, cache_path: &Path) {
+    let cache = PrCache {
+        branch: branch.to_string(),
+        pr: fetch_pr(branch, repo_dir),
+        fetched_at: now_secs(),
+    };
+
+    write_cache(cache_path, &cache);
+    let _ = fs::remove_file(cache_path.with_extension("lock"));
+}
+
+fn fetch_pr(branch: &str, repo_dir: &Path) -> Option<PrInfo> {
+    let output = Command::new("gh")
+        .current_dir(repo_dir)
+        .args(["pr", "view", branch, "--json", "number,url"])
+        .output()
+        .ok()?;
+
+    // A non-zero exit usually just means there's no PR for this branch.
+    if !output.status.success() {
+        return None;
+    }
+
+    serde_json::from_slice(&output.stdout).ok()
+}
+
+fn write_cache(path: &Path, cache: &PrCache) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    // Write to a temp file and rename so a concurrent reader never sees a
+    // half-written cache.
+    let tmp = path.with_extension("tmp");
+    if let Ok(mut file) = File::create(&tmp) {
+        if serde_json::to_writer(&mut file, cache).is_ok() && file.flush().is_ok() {
+            let _ = fs::rename(&tmp, path);
+        }
+    }
+}

--- a/src/powerline.rs
+++ b/src/powerline.rs
@@ -6,7 +6,7 @@ use crate::colors::Color;
 use crate::config;
 use crate::config::{LineSegment, SeparatorStyle, TerminalRuntimeMetadata};
 use crate::modules::{
-    Cargo, Cmd, Cwd, Git, Host, LastCmdDuration, Module, Nvm, PythonEnv, ReadOnly, SdkmanJava,
+    Cargo, Cmd, Cwd, Git, Host, LastCmdDuration, Module, Nvm, Pr, PythonEnv, ReadOnly, SdkmanJava,
     ShellName, Spacer, Time, User,
 };
 use crate::terminal::*;
@@ -182,7 +182,13 @@ impl Powerline {
     }
 
     #[inline(always)]
-    fn write_segment<D: Display>(&mut self, seg: D, style: Style, spaces: bool) -> fmt::Result {
+    fn write_segment<D: Display>(
+        &mut self,
+        seg: D,
+        style: Style,
+        spaces: bool,
+        visible_width: Option<usize>,
+    ) -> fmt::Result {
         // write the last style's separator on the new style's background
         if self.last_padding {
             write!(
@@ -220,8 +226,11 @@ impl Powerline {
         };
 
         // attempt to account for symbols in the segment by assuming all chars
-        // printed are of length 1
-        self.left_columns += self.left_buffer[orig_len..].chars().count();
+        // printed are of length 1. When the segment carries invisible escapes
+        // (e.g. a hyperlink) the caller passes the real visible width instead.
+        self.left_columns += visible_width
+            .map(|width| width + if spaces { 2 } else { 0 })
+            .unwrap_or_else(|| self.left_buffer[orig_len..].chars().count());
 
         self.last_style = Some(style);
         Ok(())
@@ -232,6 +241,7 @@ impl Powerline {
         seg: D,
         style: Style,
         spaces: bool,
+        visible_width: Option<usize>,
     ) -> fmt::Result {
         // write the separator directly onto the current background
         write!(
@@ -255,8 +265,12 @@ impl Powerline {
         };
 
         // attempt to account for symbols in the segment by assuming all chars
-        // printed are of length 1 (so multi-byte chars don't over-inflate the size)
-        self.right_columns += self.right_buffer[orig_len..].chars().count();
+        // printed are of length 1 (so multi-byte chars don't over-inflate the
+        // size). When the segment carries invisible escapes (e.g. a hyperlink)
+        // the caller passes the real visible width instead.
+        self.right_columns += visible_width
+            .map(|width| width + if spaces { 2 } else { 0 })
+            .unwrap_or_else(|| self.right_buffer[orig_len..].chars().count());
 
         self.last_style_right = Some(style);
         Ok(())
@@ -264,15 +278,27 @@ impl Powerline {
 
     pub fn add_segment<D: Display>(&mut self, seg: D, style: Style) {
         let _ = match self.direction {
-            Direction::Left => self.write_segment(seg, style, true),
-            Direction::Right => self.write_segment_right(seg, style, true),
+            Direction::Left => self.write_segment(seg, style, true, None),
+            Direction::Right => self.write_segment_right(seg, style, true, None),
         };
     }
 
     pub fn add_short_segment<D: Display>(&mut self, seg: D, style: Style) {
         let _ = match self.direction {
-            Direction::Left => self.write_segment(seg, style, false),
-            Direction::Right => self.write_segment_right(seg, style, false),
+            Direction::Left => self.write_segment(seg, style, false, None),
+            Direction::Right => self.write_segment_right(seg, style, false, None),
+        };
+    }
+
+    /// Adds a segment whose text is an OSC 8 terminal hyperlink. The escape
+    /// sequences are invisible, so the segment's visible width is computed from
+    /// `label` alone to keep column accounting (and right-prompt padding) correct.
+    pub fn add_hyperlink_segment(&mut self, label: &str, url: &str, style: Style) {
+        let visible_width = label.chars().count();
+        let seg = format!("\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\", url, label);
+        let _ = match self.direction {
+            Direction::Left => self.write_segment(seg, style, true, Some(visible_width)),
+            Direction::Right => self.write_segment_right(seg, style, true, Some(visible_width)),
         };
     }
 
@@ -301,6 +327,7 @@ impl Powerline {
                 }
                 LineSegment::Cargo => self.add_module(Cargo::<T>::new()),
                 LineSegment::Git => self.add_module(Git::<T>::new()),
+                LineSegment::Pr => self.add_module(Pr::<T>::new()),
                 LineSegment::Separator(style) => self.set_separator(style.into()),
                 LineSegment::ReadOnly => self.add_module(ReadOnly::<T>::new()),
                 LineSegment::Host => self.add_module(Host::<T>::new()),

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -5,8 +5,8 @@ pub use simple::SimpleTheme;
 use crate::colors::Color;
 use crate::modules::{
     CargoScheme, CmdScheme, CwdScheme, ExitCodeScheme, GitScheme, HostScheme,
-    LastCmdDurationScheme, NvmScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme, ShellScheme,
-    SpacerScheme, TimeScheme, UserScheme,
+    LastCmdDurationScheme, NvmScheme, PrScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme,
+    ShellScheme, SpacerScheme, TimeScheme, UserScheme,
 };
 
 mod custom;
@@ -41,6 +41,7 @@ pub trait CompleteTheme:
     + LastCmdDurationScheme
     + ExitCodeScheme
     + GitScheme
+    + PrScheme
     + PythonEnvScheme
     + ReadOnlyScheme
     + SpacerScheme

--- a/src/themes/custom.rs
+++ b/src/themes/custom.rs
@@ -10,8 +10,8 @@ use serde_json::Value;
 use crate::colors::Color;
 use crate::modules::{
     CargoScheme, CmdScheme, CwdScheme, ExitCodeScheme, GitScheme, HostScheme,
-    LastCmdDurationScheme, NvmScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme, ShellScheme,
-    SpacerScheme, TimeScheme, UserScheme,
+    LastCmdDurationScheme, NvmScheme, PrScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme,
+    ShellScheme, SpacerScheme, TimeScheme, UserScheme,
 };
 use crate::themes::{CompleteTheme, DefaultColors};
 
@@ -217,6 +217,17 @@ impl GitScheme for CustomTheme {
     color_from_json!(git_repo_clean_fg, git, clean_fg, default_fg);
     color_from_json!(git_repo_dirty_bg, git, dirty_bg, default_bg);
     color_from_json!(git_repo_dirty_fg, git, dirty_fg, default_fg);
+}
+
+impl PrScheme for CustomTheme {
+    color_from_json!(pr_bg, pr, bg, default_bg);
+    color_from_json!(pr_fg, pr, fg, default_fg);
+
+    fn pr_icon() -> &'static str {
+        Self::get_str("pr", "icon")
+            .map(|str| str.leak() as &'static str)
+            .unwrap_or("\u{ea64}")
+    }
 }
 
 impl PythonEnvScheme for CustomTheme {

--- a/src/themes/custom.rs
+++ b/src/themes/custom.rs
@@ -220,8 +220,14 @@ impl GitScheme for CustomTheme {
 }
 
 impl PrScheme for CustomTheme {
-    color_from_json!(pr_bg, pr, bg, default_bg);
-    color_from_json!(pr_fg, pr, fg, default_fg);
+    color_from_json!(pr_draft_bg, pr, draft_bg, default_bg);
+    color_from_json!(pr_draft_fg, pr, draft_fg, default_fg);
+    color_from_json!(pr_open_bg, pr, open_bg, default_bg);
+    color_from_json!(pr_open_fg, pr, open_fg, default_fg);
+    color_from_json!(pr_merged_bg, pr, merged_bg, default_bg);
+    color_from_json!(pr_merged_fg, pr, merged_fg, default_fg);
+    color_from_json!(pr_closed_bg, pr, closed_bg, default_bg);
+    color_from_json!(pr_closed_fg, pr, closed_fg, default_fg);
 
     fn pr_icon() -> &'static str {
         Self::get_str("pr", "icon")

--- a/src/themes/rainbow.rs
+++ b/src/themes/rainbow.rs
@@ -175,11 +175,29 @@ impl GitScheme for RainbowTheme {
 }
 
 impl PrScheme for RainbowTheme {
-    fn pr_fg() -> Color {
+    fn pr_draft_fg() -> Color {
         white()
     }
-    fn pr_bg() -> Color {
+    fn pr_draft_bg() -> Color {
+        mid_grey()
+    }
+    fn pr_open_fg() -> Color {
+        white()
+    }
+    fn pr_open_bg() -> Color {
+        forest_green()
+    }
+    fn pr_merged_fg() -> Color {
+        white()
+    }
+    fn pr_merged_bg() -> Color {
         nice_purple()
+    }
+    fn pr_closed_fg() -> Color {
+        white()
+    }
+    fn pr_closed_bg() -> Color {
+        mid_red()
     }
 }
 

--- a/src/themes/rainbow.rs
+++ b/src/themes/rainbow.rs
@@ -2,8 +2,8 @@ use crate::colors::Color;
 use crate::colors::*;
 use crate::modules::{
     CargoScheme, CmdScheme, CwdScheme, ExitCodeScheme, GitScheme, HostScheme,
-    LastCmdDurationScheme, NvmScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme, ShellScheme,
-    SpacerScheme, TimeScheme, UserScheme,
+    LastCmdDurationScheme, NvmScheme, PrScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme,
+    ShellScheme, SpacerScheme, TimeScheme, UserScheme,
 };
 use crate::themes::{CompleteTheme, DefaultColors};
 
@@ -171,6 +171,15 @@ impl GitScheme for RainbowTheme {
     }
     fn git_repo_dirty_fg() -> Color {
         white()
+    }
+}
+
+impl PrScheme for RainbowTheme {
+    fn pr_fg() -> Color {
+        white()
+    }
+    fn pr_bg() -> Color {
+        nice_purple()
     }
 }
 

--- a/src/themes/simple.rs
+++ b/src/themes/simple.rs
@@ -112,10 +112,28 @@ impl TimeScheme for SimpleTheme {
 }
 
 impl PrScheme for SimpleTheme {
-    fn pr_bg() -> Color {
+    fn pr_draft_bg() -> Color {
+        Color(240)
+    }
+    fn pr_draft_fg() -> Color {
+        Color(15)
+    }
+    fn pr_open_bg() -> Color {
+        Color(28)
+    }
+    fn pr_open_fg() -> Color {
+        Color(15)
+    }
+    fn pr_merged_bg() -> Color {
         Color(54)
     }
-    fn pr_fg() -> Color {
+    fn pr_merged_fg() -> Color {
+        Color(15)
+    }
+    fn pr_closed_bg() -> Color {
+        Color(124)
+    }
+    fn pr_closed_fg() -> Color {
         Color(15)
     }
 }

--- a/src/themes/simple.rs
+++ b/src/themes/simple.rs
@@ -1,8 +1,8 @@
 use crate::colors::{black, dark_grey, grey, light_grey, Color};
 use crate::modules::{
     CargoScheme, CmdScheme, CwdScheme, ExitCodeScheme, GitScheme, HostScheme,
-    LastCmdDurationScheme, NvmScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme, ShellScheme,
-    SpacerScheme, TimeScheme, UserScheme,
+    LastCmdDurationScheme, NvmScheme, PrScheme, PythonEnvScheme, ReadOnlyScheme, SdkmanScheme,
+    ShellScheme, SpacerScheme, TimeScheme, UserScheme,
 };
 use crate::themes::{CompleteTheme, DefaultColors};
 
@@ -108,6 +108,15 @@ impl TimeScheme for SimpleTheme {
     }
     fn time_fg() -> Color {
         Color(250)
+    }
+}
+
+impl PrScheme for SimpleTheme {
+    fn pr_bg() -> Color {
+        Color(54)
+    }
+    fn pr_fg() -> Color {
+        Color(15)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a new **`pr`** module that shows a clickable link to the open GitHub PR for the current branch, if one exists.

The key constraint was to never block prompt rendering on a network request. This is handled with a cache + detached background refresh:

- On render, the module reads a cache file keyed by repo root + branch (under `$XDG_CACHE_HOME`, falling back to `~/.cache`).
- If the cache is **missing or stale** (>60s), it spawns a **detached background process** (hidden `refresh-pr` subcommand) that runs `gh pr view <branch>` and writes the result. The current prompt renders immediately with whatever is cached (possibly nothing); the link shows up on a subsequent prompt.
- The link itself is an **OSC 8 terminal hyperlink** (`<icon> #123` → PR URL). `Powerline::add_hyperlink_segment` accounts for the invisible escape sequences so right-prompt column/padding math stays correct.

### Safeguards

- **Skips entirely on `develop`/`main`/`master`** (and detached `HEAD`) — no git or `gh` work at all.
- A `.lock` file debounces concurrent prompts so only one `gh` runs at a time (20s window).
- The background child's stdio is redirected to `/dev/null` so the shell's command substitution doesn't block on the inherited pipe.
- "No PR exists" results are cached too, so we don't re-query every prompt.
- Cache writes are atomic (temp file + rename).

### Usage

Add `"pr"` to a row's segment list in `config.json`. Requires the [`gh`](https://cli.github.com) CLI to be authenticated. Custom themes can set `pr` `bg`/`fg`/`icon`.

## Testing

Manually verified end-to-end with the dev binary:
- No cache → renders nothing, spawns background refresh that writes the cache.
- "No PR" branch → caches `pr: null`, renders nothing.
- PR-present cache → renders the OSC 8 hyperlink (rainbow + custom themes).
- Fresh cache → no duplicate refresh spawned.
- `develop` branch (via worktree) → skipped entirely, no cache dir created.

`cargo cleanup`, `cargo clippy --all-targets`, and `cargo test` all clean.