### PR TITLE
feat: add CI build + default-config parsing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build & test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    name: Build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Test
+        run: cargo test --verbose

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,3 +106,28 @@ impl Default for Config {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The binary writes `Config::default()` to disk with `to_string_pretty`
+    /// and then reads it back with `from_reader`. This guards that round-trip:
+    /// the serialized default config must always deserialize into an equivalent
+    /// `Config`, so a fresh install never ends up with an unparsable config.
+    #[test]
+    fn default_config_round_trips() {
+        let default = Config::default();
+
+        let json = serde_json::to_string_pretty(&default)
+            .expect("default config should serialize to JSON");
+
+        let parsed: Config =
+            serde_json::from_str(&json).expect("serialized default config should parse back");
+
+        // Compare via the canonical JSON form to confirm the round-trip is lossless.
+        let reserialized = serde_json::to_string_pretty(&parsed)
+            .expect("reparsed config should serialize to JSON");
+        assert_eq!(json, reserialized);
+    }
+}

--- a/tests/default_config.rs
+++ b/tests/default_config.rs
@@ -1,0 +1,53 @@
+//! End-to-end check that the compiled binary can generate and parse its
+//! default configuration.
+//!
+//! On first run with no existing config, `powerline show` writes
+//! `Config::default()` to `$HOME/.config/powerline-rs/config.json` and then
+//! immediately reads it back. If that round-trip ever broke, a fresh install
+//! would fail to render a prompt. This test drives the real binary against a
+//! throwaway `$HOME` to make sure that path stays healthy.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Path to the binary compiled by Cargo for this integration test run.
+const BIN: &str = env!("CARGO_BIN_EXE_powerline");
+
+fn scratch_home() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("powerline-rs-it-{}", std::process::id()));
+    // Start from a clean slate so we exercise the "create default config" path.
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create scratch home");
+    dir
+}
+
+#[test]
+fn default_config_parses_with_compiled_binary() {
+    let home = scratch_home();
+
+    let output = Command::new(BIN)
+        .args(["show", "fish", "-s", "0", "-c", "80"])
+        .env("HOME", &home)
+        .output()
+        .expect("failed to run the powerline binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The default config is created on this path before anything is rendered.
+    let config_path = home.join(".config/powerline-rs/config.json");
+    assert!(
+        config_path.is_file(),
+        "binary did not create the default config at {}\nstderr:\n{stderr}",
+        config_path.display(),
+    );
+
+    // `load_config` reports a parse failure with this exact message. Its absence
+    // means the freshly written default config deserialized cleanly.
+    assert!(
+        !stderr.contains("config file could not be parsed"),
+        "default config failed to parse via the binary\nstderr:\n{stderr}",
+    );
+
+    let _ = fs::remove_dir_all(&home);
+}


### PR DESCRIPTION
## Summary

Adds a basic CI pipeline and test coverage for the default configuration.

### CI (`.github/workflows/ci.yml`)
Runs on every push to `main` and on all pull requests:
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `cargo test`

Uses `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` for a fast, reproducible build on `ubuntu-latest`.

### Tests
- **Unit round-trip** (`src/config.rs`): `Config::default()` serializes with `to_string_pretty` and deserializes back losslessly — guards the exact write/read path the binary uses on first run.
- **Integration test** (`tests/default_config.rs`): runs the **compiled binary** against a throwaway `$HOME`, confirming it creates `~/.config/powerline-rs/config.json` from the default config and parses it back without error.

## Verification
`cargo fmt --check`, `cargo clippy -D warnings`, and `cargo test` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)