### PR TITLE
docs: install from crates.io and add a crates.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # superline
 
+[![crates.io](https://img.shields.io/crates/v/superline.svg)](https://crates.io/crates/superline)
+
 _Forked from [cirho/powerline-rust](https://github.com/cirho/powerline-rust) and adjusted for personal taste_
 
 superline supports git and github natively, and detects rust, python, node and java environments.
@@ -37,7 +39,7 @@ seems to fix some character alignment issues.
 To install the package, just run the following:
 
 ```bash
-cargo install --git https://github.com/alxhill/superline.git
+cargo install superline
 superline install <shell name>
 ```
 


### PR DESCRIPTION
## Summary

`superline` is now published on [crates.io](https://crates.io/crates/superline) (v0.5.0), so:
- The install instructions now use `cargo install superline` instead of building from the git repo.
- Added a crates.io version badge under the title: [![crates.io](https://img.shields.io/crates/v/superline.svg)](https://crates.io/crates/superline)

## Verification
Confirmed `superline` v0.5.0 resolves on the crates.io API, so the badge and the `cargo install` command both work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)