### PR TITLE
feat(pr): only show status indicator for in-progress PRs

### DIFF
--- a/src/modules/pr.rs
+++ b/src/modules/pr.rs
@@ -100,6 +100,12 @@ enum PrState {
 }
 
 impl PrState {
+    /// Whether the PR is still in progress (open or draft, but not merged or
+    /// closed). Only these PRs show the CI status indicator.
+    fn is_open(self) -> bool {
+        matches!(self, PrState::Open | PrState::Draft)
+    }
+
     /// Picks the (fg, bg) colors for this state from the active scheme.
     fn style<S: PrScheme>(self) -> (Color, Color) {
         match self {
@@ -183,9 +189,10 @@ impl<S: PrScheme> Module for Pr<S> {
             let (fg, bg) = pr.state.style::<S>();
 
             // The CI status, when enabled and meaningful, renders as a coloured
-            // dot tucked into the same segment right after the PR number.
-            let marker = self
-                .show_status
+            // dot tucked into the same segment right after the PR number. It's
+            // only shown while a PR is still in progress - the checks are stale
+            // or irrelevant once a PR is merged or closed.
+            let marker = (self.show_status && pr.state.is_open())
                 .then(|| {
                     pr.checks
                         .map(|status| (S::pr_status_icon(), status.fg::<S>()))


### PR DESCRIPTION
## Summary

The PR module's CI status indicator (the coloured dot after the PR number) is now shown only while a PR is **open or in draft**. Once a PR is **merged or closed**, its checks are stale or irrelevant, so the dot is hidden.

## Changes

- Added `PrState::is_open()`, true for `Open` and `Draft`.
- Gated the status `marker` on `self.show_status && pr.state.is_open()` in `append_segments`.

## Test plan

- `cargo cleanup` passes (check + fmt + clippy).
- Verified the dot renders for open/draft PRs and is hidden for merged/closed ones.