### PR TITLE
docs: use absolute image URLs in README so they render on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ _Forked from [cirho/powerline-rust](https://github.com/cirho/powerline-rust) and
 
 superline supports git and github natively, and detects rust, python, node and java environments.
 
-![Shell with pyenv showing](with_pyenv.png)
+![Shell with pyenv showing](https://raw.githubusercontent.com/alxhill/superline/main/with_pyenv.png)
 
 It integrates with the `gh` shell command to provide PR and CI status check display as well.
 
-![Shell with PR link and status check](with_status.png)
+![Shell with PR link and status check](https://raw.githubusercontent.com/alxhill/superline/main/with_status.png)
 
 superline is a pure-rust version of [powerline-SHELL](https://github.com/b-ryan/powerline-shell). It's heavily
 inspired
@@ -34,7 +34,7 @@ downloaded in patched form [here](https://github.com/ryanoasis/nerd-fonts/releas
 iTerm2 users are recommended to enable the "Use builtin Powerline glyphs" option even when using a Nerd Font as this
 seems to fix some character alignment issues.
 
-![iTerm2 Profile configuration](iterm_config.png)
+![iTerm2 Profile configuration](https://raw.githubusercontent.com/alxhill/superline/main/iterm_config.png)
 
 To install the package, just run the following:
 


### PR DESCRIPTION
## Summary

The README screenshots don't appear on the crates.io crate page. crates.io's HTML sanitizer **strips relative image `src` attributes** — verified against the already-published v0.5.0 README, whose rendered `<img>` tags came back with only `alt` and no `src`:

```
<img alt="Shell with pyenv showing">
<img alt="Shell with PR link and status check">
<img alt="iTerm2 Profile configuration">
```

(Note: bundling the PNGs into the crate tarball does **not** help — crates.io serves the README from its own domain and never references files inside the crate.)

This switches the three screenshot references from relative paths to absolute `raw.githubusercontent.com` URLs, which render on both crates.io and GitHub. All three return HTTP 200.

## Changes

- `with_pyenv.png`, `with_status.png`, `iterm_config.png` → `https://raw.githubusercontent.com/alxhill/superline/main/<file>`

## Test plan

- Verified each raw URL returns `200`.
- Renders unchanged on GitHub (absolute URLs work there too).