### PR TITLE
feat(shell): add PowerShell (pwsh) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,24 @@ superline install <shell name>
 ```
 
 Then reload your shell's config. Superline will modify the default config file for the shell you choose - currently,
-`fish`, `zsh`, and `bash`.
+`fish`, `zsh`, `bash`, and `pwsh` (PowerShell). For example, `superline install pwsh` appends the loader to your
+PowerShell profile (`$PROFILE`), creating it if necessary.
 
 Cargo's bin directory must be in your `$PATH` for the `superline` command to be available.
+
+### PowerShell support
+
+`pwsh` is supported wherever PowerShell runs the same way it is for the Unix shells: the prompt shows the cwd, git,
+PR, environment, and command segments, the exit status of the previous command (native exit code or `$?`), the
+terminal width, and the last command's duration (read from session history). PowerShell uses bare ANSI/VT escapes
+that PSReadLine renders directly, so no extra configuration is needed. As with `bash`, there is no native
+right-hand prompt, so the final row only shows its left side (multi-row prompts still render right-aligned
+segments on the non-final rows).
+
+PowerShell Core (`pwsh` 7+) on macOS and Linux is the tested configuration. Running on Windows additionally requires
+the binary itself to be ported off its current Unix-only assumptions (the `users` crate and `$HOME`); see
+[`docs/powershell-testing.md`](docs/powershell-testing.md) for the full cross-platform testing plan and the Windows
+follow-up.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -49,19 +49,6 @@ PowerShell profile (`$PROFILE`), creating it if necessary.
 
 Cargo's bin directory must be in your `$PATH` for the `superline` command to be available.
 
-### PowerShell support
-
-`pwsh` is supported wherever PowerShell runs the same way it is for the Unix shells: the prompt shows the cwd, git,
-PR, environment, and command segments, the exit status of the previous command (native exit code or `$?`), the
-terminal width, and the last command's duration (read from session history). PowerShell uses bare ANSI/VT escapes
-that PSReadLine renders directly, so no extra configuration is needed. As with `bash`, there is no native
-right-hand prompt, so the final row only shows its left side (multi-row prompts still render right-aligned
-segments on the non-final rows).
-
-PowerShell Core (`pwsh` 7+) on macOS and Linux is the tested configuration. Running on Windows additionally requires
-the binary itself to be ported off its current Unix-only assumptions (the `users` crate and `$HOME`); see
-[`docs/powershell-testing.md`](docs/powershell-testing.md) for the full cross-platform testing plan and the Windows
-follow-up.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ superline install <shell name>
 
 Then reload your shell's config. Superline will modify the default config file for the shell you choose - currently,
 `fish`, `zsh`, `bash`, and `pwsh` (PowerShell). For example, `superline install pwsh` appends the loader to your
-PowerShell profile (`$PROFILE`), creating it if necessary.
+PowerShell profile (`$PROFILE`), creating it if necessary. PowerShell is not yet tested on Windows.
 
 Cargo's bin directory must be in your `$PATH` for the `superline` command to be available.
 

--- a/docs/powershell-testing.md
+++ b/docs/powershell-testing.md
@@ -47,7 +47,7 @@ Manual:
 - [x] `superline install pwsh` resolves `$PROFILE`, creates the
       `~/.config/powershell` directory and profile file when missing, and
       appends the loader; the resulting profile defines `prompt` and sets
-      `$env:SUPERLINE`.
+      `$env:SUPERLINE_PWSH`.
 - [x] Status: failing native command (`sh -c 'exit 7'`) → `7` in the red
       segment; success → normal segment; failing cmdlet → `1`.
 - [x] Duration arithmetic from `Start/EndExecutionTime` produces correct ms.

--- a/docs/powershell-testing.md
+++ b/docs/powershell-testing.md
@@ -1,0 +1,151 @@
+# PowerShell support — testing plan
+
+This document records what has been verified for the `pwsh` integration and lays
+out a test plan for the platforms and terminals that can't be exercised from the
+development machine.
+
+## How the integration works
+
+`superline install pwsh` appends a loader to the current-user PowerShell profile
+(resolved by asking PowerShell itself for `$PROFILE.CurrentUserCurrentHost`, so
+it is correct on every platform). The loader runs `superline init pwsh`, which
+emits a `prompt` function. On each prompt PowerShell calls that function, which:
+
+- captures `$?` **then** `$LASTEXITCODE` (order matters — any statement, even an
+  assignment, resets `$?`) and maps them to a status string (`0` on success,
+  the native exit code on failure, `1` for cmdlet failures with no exit code);
+- reads the terminal width from `$Host.UI.RawUI.WindowSize.Width` (falling back
+  to `80` when it isn't available, e.g. when output is redirected);
+- reads the last command's duration in milliseconds from `Get-History`;
+- invokes `superline show … pwsh <duration>` and returns its output joined with
+  newlines (using `-join`, not `Out-String`, which would wrap/pad to the host
+  width);
+- restores `$LASTEXITCODE` so the user's value is not clobbered.
+
+Internally `pwsh` maps to the same "bare escape" rendering mode as `fish`:
+PSReadLine parses ANSI/VT escape sequences itself, so no `\[ \]` (bash) or
+`%{ %}` (zsh) non-printing markers are emitted. As with `bash`, there is no
+native right-hand prompt; the final prompt row shows only its left side.
+
+## Verified on this machine (macOS, automated + manual)
+
+Platform: macOS (darwin 25.5), PowerShell 7.5.4 (`pwsh`).
+
+Automated (`cargo test`, see `tests/shell_rendering.rs`):
+
+- [x] `pwsh` renders bare ANSI escapes, never bash/zsh markers.
+- [x] `pwsh` output is byte-for-byte identical to `fish`.
+- [x] bash/zsh keep their own marker styles (regression guard).
+- [x] End-to-end: the generated `prompt` function loads in a real `pwsh`,
+      renders a prompt, threads a failing native command's exit code into a red
+      status segment, and preserves `$LASTEXITCODE`. (Skips cleanly if `pwsh`
+      isn't on PATH, so CI without PowerShell still passes.)
+
+Manual:
+
+- [x] `superline init pwsh` emits a valid, loadable profile snippet.
+- [x] `superline install pwsh` resolves `$PROFILE`, creates the
+      `~/.config/powershell` directory and profile file when missing, and
+      appends the loader; the resulting profile defines `prompt` and sets
+      `$env:SUPERLINE`.
+- [x] Status: failing native command (`sh -c 'exit 7'`) → `7` in the red
+      segment; success → normal segment; failing cmdlet → `1`.
+- [x] Duration arithmetic from `Start/EndExecutionTime` produces correct ms.
+- [x] `$LASTEXITCODE` is preserved across prompt rendering.
+
+## Test matrix for other platforms
+
+Run the **functional checklist** below in each configuration.
+
+| # | OS | PowerShell | Terminal | Notes |
+|---|-----|-----------|----------|-------|
+| 1 | Linux | `pwsh` 7+ | any modern (VTE/xterm) | Expected to match macOS exactly. |
+| 2 | Windows 10/11 | `pwsh` 7+ | Windows Terminal | Primary Windows target; full Unicode + OSC 8. |
+| 3 | Windows 10/11 | `pwsh` 7+ | VS Code integrated terminal | Common dev setup. |
+| 4 | Windows 10/11 | Windows PowerShell 5.1 | Windows Terminal | Ships with the OS; PSReadLine 2.0. |
+| 5 | Windows 10/11 | Windows PowerShell 5.1 | legacy `conhost.exe` | Verify VT processing + glyph fallback. |
+| 6 | macOS | `pwsh` 7+ | iTerm2 / Terminal.app | Sanity re-check on a second terminal. |
+
+> ⚠️ **Windows requires a binary port first.** The crate currently depends on the
+> Unix-only `users` crate and reads `$HOME` directly (see "Known limitations").
+> Until that work lands, configurations 2–5 cannot be built/run on Windows even
+> though the PowerShell integration itself is correct. On macOS/Linux the
+> integration is complete today.
+
+## Functional checklist (per configuration)
+
+Setup:
+
+1. `cargo install --path .` (or copy the release binary) and ensure it is on
+   `PATH` (`Get-Command superline`).
+2. `superline install pwsh`, then open a new PowerShell session.
+
+Checks:
+
+- [ ] **Loads cleanly** — new session shows the prompt with no errors or stray
+      text (the one-time "creating default conf" notice is expected only on the
+      very first prompt).
+- [ ] **cwd** renders, with `~` substituted for the home directory.
+- [ ] **git** segment appears inside a repo (branch + dirty/ahead/behind state).
+- [ ] **PR** segment appears for a branch with an open PR (requires `gh`), and
+      the OSC 8 hyperlink is clickable in terminals that support it
+      (Windows Terminal yes; legacy conhost no — should degrade to plain text).
+- [ ] **environment** segments (python venv / cargo / node / java) show when
+      applicable.
+- [ ] **exit status** — run a failing native command and confirm the red status
+      segment shows the code:
+      - Windows: `cmd /c exit 5`
+      - Unix: `sh -c 'exit 5'`
+      Then run a successful command and confirm it returns to normal.
+- [ ] **cmdlet failure** — `Get-Item C:\does-not-exist` (or `/nope`) shows a
+      failure status (`1`).
+- [ ] **command duration** — `Start-Sleep -Seconds 2` shows a duration segment
+      on the next prompt; a fast command shows none (respecting `min_run_time`).
+- [ ] **terminal width** — with a multi-row prompt that uses a `right` section,
+      resize the window and confirm right-aligned segments track the new width
+      and don't wrap.
+- [ ] **multiline editing** — type a long command, use ↑/↓ history recall and
+      `Ctrl+R` search; the prompt must not smear or miscalculate the cursor
+      column (this exercises PSReadLine's ANSI-aware width handling).
+- [ ] **glyphs** — separators and icons render with a Nerd Font; with a
+      non-Nerd font they should fall back to boxes/blanks but not corrupt layout.
+- [ ] **`$LASTEXITCODE` preserved** — run a native command, then on the next
+      line `$LASTEXITCODE` still reports that command's code.
+- [ ] **redirect safety** — `(prompt) | Out-Null` and running under a
+      non-interactive host don't throw (WindowSize fallback path).
+- [ ] **performance** — prompt latency feels instant in a git repo (cache warm).
+
+### Windows PowerShell 5.1 specifics
+
+- [ ] PSReadLine ≥ 2.0 is present (`Get-Module PSReadLine`); older 5.1 boxes may
+      need `Install-Module PSReadLine`.
+- [ ] ANSI/VT processing is enabled (Windows 10 1511+ enables it; legacy hosts
+      may need `[console]::OutputEncoding` / VT enabling). If escapes show as
+      literal text, that's the host, not superline.
+- [ ] `$PROFILE.CurrentUserCurrentHost` resolves under
+      `Documents\WindowsPowerShell\` (5.1) vs `Documents\PowerShell\` (7+); the
+      installer should write to the correct one because it asks PowerShell.
+- [ ] Output encoding is UTF-8 so Nerd Font glyphs aren't mangled
+      (`$OutputEncoding` / `chcp 65001` for legacy conhost).
+
+## Known limitations & follow-ups
+
+- **Windows binary port (blocker for configs 2–5).** To build and run on
+  Windows the crate needs:
+  - `users` crate usage replaced with a cross-platform alternative. It's used
+    for root detection in `src/modules/cmd.rs` (`get_current_uid() == 0`) and
+    for the current user name in `src/modules/user.rs`. On Windows, gate these
+    behind `#[cfg(unix)]` and provide a Windows path (e.g. default to
+    non-root / use `USERNAME`, or detect elevation via the Win32 API).
+  - `$HOME` reads replaced with a portable home lookup (`USERPROFILE` on
+    Windows, or the `dirs` crate). Affected: config path in
+    `src/bin/superline.rs` (`get_or_create_conf_file`), `~` substitution in
+    `src/modules/cwd.rs`, and the PR cache dir in `src/modules/pr.rs`
+    (`XDG_CACHE_HOME`/`HOME` → `LOCALAPPDATA` on Windows).
+  These are pre-existing Unix assumptions shared by all shells, not introduced
+  by the PowerShell work; the `pwsh` profile-path detection already avoids
+  `$HOME`.
+- **No native right prompt**, matching bash. Right-aligned segments only render
+  on non-final rows of a multi-row prompt.
+- **OSC 8 hyperlinks** (PR segment) require a terminal that supports them;
+  legacy `conhost.exe` shows the label as plain text (no breakage).

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -300,8 +300,6 @@ fn powershell_profile_path() -> PathBuf {
 }
 
 fn append_conf(conf_path: PathBuf, conf_contents: &str) {
-    // The PowerShell profile (and occasionally a fresh shell rc) may not exist
-    // yet, so create the parent directory and file if needed before appending.
     if let Some(parent) = conf_path.parent() {
         create_dir_all(parent).unwrap_or_else(|e| {
             panic!(

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -258,13 +258,13 @@ fn install(args: InstallArgs) {
     // shell of a different kind (whose parent only exports its own marker).
     if env::var(shell.marker_env_var()).is_ok() && !args.force {
         println!(
-            "powerline already installed in current {} shell",
+            "superline already installed in current {} shell",
             shell.name()
         );
         return;
     }
 
-    println!("Installing powerline for {} shell", shell.name());
+    println!("Installing superline for {} shell", shell.name());
 
     match shell {
         ShellArg::Fish => append_conf(home_config(".config/fish/config.fish"), FISH_INSTALL),
@@ -376,7 +376,7 @@ fn show(args: ShowArgs, right_only: bool) {
             }
         }
         Err(e) => {
-            eprintln!("powerline error: {}", e);
+            eprintln!("superline error: {}", e);
             if let Some(source) = e.source() {
                 eprintln!("source:\n\t{}", source);
             }

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -19,7 +19,7 @@ use superline::themes::{CustomTheme, RainbowTheme, SimpleTheme};
 use superline::Powerline;
 
 const FISH_CONF: &str = r#"
-set -gx SUPERLINE 1
+set -gx SUPERLINE_FISH 1
 
 function __pl_cache_duration --on-event fish_postexec
   set -gx __pl_duration $CMD_DURATION
@@ -40,7 +40,7 @@ superline init fish | source
 "#;
 
 const ZSH_CONF: &str = r#"
-export SUPERLINE=1
+export SUPERLINE_ZSH=1
 
 function preexec() {
     if command -v gdate >/dev/null 2>&1; then
@@ -70,7 +70,7 @@ source <(superline init zsh)
 
 // note: does not support showing last cmd duration
 const BASH_CONF: &str = r#"
-export SUPERLINE=1
+export SUPERLINE_BASH=1
 
 function _update_ps1() {
     PS1="$(superline show -s $? -c $COLUMNS bash)"
@@ -91,7 +91,7 @@ source <(superline init bash)
 // special non-printing markers are needed. There is no native right-prompt, so
 // like bash the final row only shows its left side.
 const PWSH_CONF: &str = r#"
-$env:SUPERLINE = 1
+$env:SUPERLINE_PWSH = 1
 
 function global:prompt {
     # Capture command state first: every statement below (even an assignment)
@@ -169,6 +169,24 @@ enum ShellArg {
     Pwsh,
 }
 
+impl ShellArg {
+    fn name(&self) -> &'static str {
+        match self {
+            ShellArg::Bash => "bash",
+            ShellArg::Zsh => "zsh",
+            ShellArg::Fish => "fish",
+            ShellArg::Pwsh => "pwsh",
+        }
+    }
+
+    /// Name of the per-shell marker env var set by that shell's init snippet
+    /// (e.g. `SUPERLINE_BASH`). Each shell uses its own variable so a nested
+    /// shell of a different kind isn't mistaken for an already-configured one.
+    fn marker_env_var(&self) -> String {
+        format!("SUPERLINE_{}", self.name().to_uppercase())
+    }
+}
+
 #[derive(Debug, Args)]
 struct ShowArgs {
     #[arg(value_enum)]
@@ -203,12 +221,7 @@ struct InstallArgs {
 
 impl TerminalRuntimeMetadata for &ShowArgs {
     fn shell_name(&self) -> String {
-        match self.shell {
-            ShellArg::Bash => "bash".to_string(),
-            ShellArg::Zsh => "zsh".to_string(),
-            ShellArg::Fish => "fish".to_string(),
-            ShellArg::Pwsh => "pwsh".to_string(),
-        }
+        self.shell.name().to_string()
     }
 
     fn total_columns(&self) -> usize {
@@ -238,14 +251,20 @@ fn main() {
 }
 
 fn install(args: InstallArgs) {
-    if env::var("SUPERLINE").is_ok() && !args.force {
-        println!("powerline already installed in current shell");
+    let shell = args.shell;
+
+    // Detect prior installation via the shell-specific marker rather than a
+    // single shared one, so superline can still be installed from a nested
+    // shell of a different kind (whose parent only exports its own marker).
+    if env::var(shell.marker_env_var()).is_ok() && !args.force {
+        println!(
+            "powerline already installed in current {} shell",
+            shell.name()
+        );
         return;
     }
 
-    let shell = args.shell;
-
-    println!("Installing powerline for {:?} shell", shell);
+    println!("Installing powerline for {} shell", shell.name());
 
     match shell {
         ShellArg::Fish => append_conf(home_config(".config/fish/config.fish"), FISH_INSTALL),

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -86,10 +86,6 @@ const BASH_INSTALL: &str = r#"
 source <(superline init bash)
 "#;
 
-// PowerShell renders the prompt from whatever the `prompt` function returns.
-// PSReadLine understands raw ANSI/VT escapes (the same ones fish uses), so no
-// special non-printing markers are needed. There is no native right-prompt, so
-// like bash the final row only shows its left side.
 const PWSH_CONF: &str = r#"
 $env:SUPERLINE_PWSH = 1
 
@@ -179,9 +175,8 @@ impl ShellArg {
         }
     }
 
-    /// Name of the per-shell marker env var set by that shell's init snippet
-    /// (e.g. `SUPERLINE_BASH`). Each shell uses its own variable so a nested
-    /// shell of a different kind isn't mistaken for an already-configured one.
+    /// Per-shell marker env var exported by that shell's init snippet (e.g.
+    /// `SUPERLINE_BASH`).
     fn marker_env_var(&self) -> String {
         format!("SUPERLINE_{}", self.name().to_uppercase())
     }
@@ -253,9 +248,8 @@ fn main() {
 fn install(args: InstallArgs) {
     let shell = args.shell;
 
-    // Detect prior installation via the shell-specific marker rather than a
-    // single shared one, so superline can still be installed from a nested
-    // shell of a different kind (whose parent only exports its own marker).
+    // A nested shell only inherits its parent's marker, so keying detection off
+    // the target shell's own marker lets install still run in nested shells.
     if env::var(shell.marker_env_var()).is_ok() && !args.force {
         println!(
             "superline already installed in current {} shell",
@@ -270,8 +264,6 @@ fn install(args: InstallArgs) {
         ShellArg::Fish => append_conf(home_config(".config/fish/config.fish"), FISH_INSTALL),
         ShellArg::Zsh => append_conf(home_config(".zshrc"), ZSH_INSTALL),
         ShellArg::Bash => append_conf(home_config(".bashrc"), BASH_INSTALL),
-        // PowerShell stores its profile in different places per platform, so ask
-        // PowerShell itself where it lives rather than guessing from $HOME.
         ShellArg::Pwsh => append_conf(powershell_profile_path(), PWSH_INSTALL),
     }
 
@@ -286,10 +278,8 @@ fn home_config(rel: &str) -> PathBuf {
     home_dir.join(rel)
 }
 
-/// Ask PowerShell for the current-user profile path. This is the portable way to
-/// find it - on Unix it resolves under `~/.config/powershell`, on Windows under
-/// the user's `Documents` directory - and avoids relying on `$HOME` (which
-/// Windows does not set).
+/// Ask PowerShell itself for the current-user profile path: it varies per
+/// platform and avoids relying on `$HOME`, which Windows does not set.
 fn powershell_profile_path() -> PathBuf {
     let run = |cmd: &str| {
         Command::new(cmd)

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -86,6 +86,58 @@ const BASH_INSTALL: &str = r#"
 source <(superline init bash)
 "#;
 
+// PowerShell renders the prompt from whatever the `prompt` function returns.
+// PSReadLine understands raw ANSI/VT escapes (the same ones fish uses), so no
+// special non-printing markers are needed. There is no native right-prompt, so
+// like bash the final row only shows its left side.
+const PWSH_CONF: &str = r#"
+$env:SUPERLINE = 1
+
+function global:prompt {
+    # Capture command state first: every statement below (even an assignment)
+    # resets $?, so read it before anything else - including before reading
+    # $LASTEXITCODE, which a plain assignment would otherwise flip back to true.
+    $__pl_ok = $?
+    $__pl_exit = $LASTEXITCODE
+
+    # Mirror the bash/zsh convention: 0 on success, otherwise the native exit
+    # code (falling back to 1 for cmdlet failures that leave $LASTEXITCODE unset).
+    if ($__pl_ok) {
+        $__pl_status = 0
+    } elseif ($__pl_exit) {
+        $__pl_status = $__pl_exit
+    } else {
+        $__pl_status = 1
+    }
+
+    $__pl_cols = 0
+    try { $__pl_cols = $Host.UI.RawUI.WindowSize.Width } catch {}
+    if (-not $__pl_cols -or $__pl_cols -le 0) { $__pl_cols = 80 }
+
+    $__pl_args = @('show', '-s', $__pl_status, '-c', $__pl_cols, 'pwsh')
+
+    # Duration of the last command, in milliseconds, from session history.
+    $__pl_last = Get-History -Count 1
+    if ($__pl_last) {
+        $__pl_ms = [long][math]::Round(($__pl_last.EndExecutionTime - $__pl_last.StartExecutionTime).TotalMilliseconds)
+        if ($__pl_ms -ge 0) { $__pl_args += $__pl_ms }
+    }
+
+    # Join lines with `n (not Out-String, which can wrap/pad to the host width).
+    $__pl_out = (& superline @__pl_args) -join "`n"
+
+    # Restore $LASTEXITCODE so our own commands don't clobber the user's value.
+    $global:LASTEXITCODE = $__pl_exit
+
+    $__pl_out
+}
+"#;
+
+const PWSH_INSTALL: &str = r#"
+# automatically added by superline
+(& superline init pwsh) -join "`n" | Invoke-Expression
+"#;
+
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 enum PowerlineArgs {
@@ -106,6 +158,7 @@ enum ShellSubcommand {
     Bash,
     Zsh,
     Fish,
+    Pwsh,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -113,6 +166,7 @@ enum ShellArg {
     Bash,
     Zsh,
     Fish,
+    Pwsh,
 }
 
 #[derive(Debug, Args)]
@@ -153,6 +207,7 @@ impl TerminalRuntimeMetadata for &ShowArgs {
             ShellArg::Bash => "bash".to_string(),
             ShellArg::Zsh => "zsh".to_string(),
             ShellArg::Fish => "fish".to_string(),
+            ShellArg::Pwsh => "pwsh".to_string(),
         }
     }
 
@@ -190,23 +245,65 @@ fn install(args: InstallArgs) {
 
     let shell = args.shell;
 
-    let home_dir = PathBuf::from(env::var("HOME").unwrap());
-
-    assert!(home_dir.is_dir(), "home directory does not exist");
-
     println!("Installing powerline for {:?} shell", shell);
 
     match shell {
-        ShellArg::Fish => append_conf(home_dir.join(".config/fish/config.fish"), FISH_INSTALL),
-        ShellArg::Zsh => append_conf(home_dir.join(".zshrc"), ZSH_INSTALL),
-        ShellArg::Bash => append_conf(home_dir.join(".bashrc"), BASH_INSTALL),
+        ShellArg::Fish => append_conf(home_config(".config/fish/config.fish"), FISH_INSTALL),
+        ShellArg::Zsh => append_conf(home_config(".zshrc"), ZSH_INSTALL),
+        ShellArg::Bash => append_conf(home_config(".bashrc"), BASH_INSTALL),
+        // PowerShell stores its profile in different places per platform, so ask
+        // PowerShell itself where it lives rather than guessing from $HOME.
+        ShellArg::Pwsh => append_conf(powershell_profile_path(), PWSH_INSTALL),
     }
 
     println!("Done, please restart your shell for changes to take effect");
 }
 
+/// Resolve a path inside the Unix `$HOME` directory used by the bash/zsh/fish
+/// config files.
+fn home_config(rel: &str) -> PathBuf {
+    let home_dir = PathBuf::from(env::var("HOME").expect("could not read $HOME env var"));
+    assert!(home_dir.is_dir(), "home directory does not exist");
+    home_dir.join(rel)
+}
+
+/// Ask PowerShell for the current-user profile path. This is the portable way to
+/// find it - on Unix it resolves under `~/.config/powershell`, on Windows under
+/// the user's `Documents` directory - and avoids relying on `$HOME` (which
+/// Windows does not set).
+fn powershell_profile_path() -> PathBuf {
+    let run = |cmd: &str| {
+        Command::new(cmd)
+            .args(["-NoProfile", "-Command", "$PROFILE.CurrentUserCurrentHost"])
+            .output()
+    };
+
+    let output = run("pwsh").or_else(|_| run("powershell")).expect(
+        "could not run pwsh/powershell to locate the profile - is PowerShell installed and on PATH?",
+    );
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert!(
+        !path.is_empty(),
+        "PowerShell returned an empty profile path"
+    );
+    PathBuf::from(path)
+}
+
 fn append_conf(conf_path: PathBuf, conf_contents: &str) {
+    // The PowerShell profile (and occasionally a fresh shell rc) may not exist
+    // yet, so create the parent directory and file if needed before appending.
+    if let Some(parent) = conf_path.parent() {
+        create_dir_all(parent).unwrap_or_else(|e| {
+            panic!(
+                "could not create config directory {}: {e}",
+                parent.display()
+            )
+        });
+    }
+
     let mut conf = OpenOptions::new()
+        .create(true)
         .append(true)
         .open(&conf_path)
         .unwrap_or_else(|_| {
@@ -236,6 +333,7 @@ fn print_shell_conf(shell: ShellSubcommand) {
         ShellSubcommand::Bash => println!("{}", BASH_CONF),
         ShellSubcommand::Zsh => println!("{}", ZSH_CONF),
         ShellSubcommand::Fish => println!("{}", FISH_CONF),
+        ShellSubcommand::Pwsh => println!("{}", PWSH_CONF),
     }
 }
 
@@ -246,6 +344,9 @@ fn show(args: ShowArgs, right_only: bool) {
                 ShellArg::Bash => SHELL.set(Shell::Bash),
                 ShellArg::Zsh => SHELL.set(Shell::Zsh),
                 ShellArg::Fish => SHELL.set(Shell::Bare),
+                // PowerShell's PSReadLine handles raw ANSI escapes itself, so it
+                // uses the same bare escapes as fish (no non-printing markers).
+                ShellArg::Pwsh => SHELL.set(Shell::Bare),
             }
             .expect("failed to set shell");
 

--- a/tests/shell_rendering.rs
+++ b/tests/shell_rendering.rs
@@ -1,0 +1,174 @@
+//! Per-shell rendering checks for the compiled binary.
+//!
+//! Each shell needs its escape sequences wrapped differently so the shell
+//! computes the prompt width correctly:
+//!   * bash wraps non-printing sequences in `\[ ... \]` readline markers
+//!   * zsh wraps them in `%{ ... %}`
+//!   * fish and PowerShell emit bare ANSI/VT escapes (their line editors parse
+//!     the escapes themselves)
+//!
+//! These tests pin that behaviour - in particular that PowerShell renders the
+//! same bare escapes as fish - without needing any shell installed. The final
+//! test additionally drives a real `pwsh` end-to-end when one is on PATH, and
+//! skips otherwise so CI without PowerShell still passes.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_superline");
+
+/// A throwaway `$HOME` so each render exercises the "create default config" path
+/// in isolation. The pid + label keep parallel test threads from colliding.
+fn scratch_home(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("superline-render-{}-{label}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create scratch home");
+    dir
+}
+
+/// Render the default prompt for `shell` against the given `$HOME`, returning
+/// the raw stdout (escape sequences and all).
+fn render_in(home: &PathBuf, shell: &str) -> String {
+    let output = Command::new(BIN)
+        .args(["show", shell, "-s", "0", "-c", "80"])
+        .env("HOME", home)
+        .output()
+        .expect("failed to run the superline binary");
+    assert!(
+        output.status.success(),
+        "`show {shell}` exited with failure\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Render against a fresh, pre-warmed `$HOME` so the one-time "creating default
+/// config" notice (which embeds the home path) never appears in the output.
+fn render(shell: &str) -> String {
+    let home = scratch_home(shell);
+    // Warm the config first so the notice is written and gone before we capture.
+    let _ = render_in(&home, shell);
+    let out = render_in(&home, shell);
+    let _ = fs::remove_dir_all(&home);
+    out
+}
+
+/// The real ESC byte that bare-escape shells (fish, PowerShell) emit.
+const ESC: char = '\x1b';
+
+#[test]
+fn powershell_uses_bare_ansi_like_fish() {
+    let pwsh = render("pwsh");
+    assert!(
+        pwsh.contains(ESC),
+        "PowerShell prompt should contain raw ANSI escapes",
+    );
+    assert!(
+        !pwsh.contains("\\["),
+        "PowerShell prompt must not use bash's \\[ \\] readline markers",
+    );
+    assert!(
+        !pwsh.contains("%{"),
+        "PowerShell prompt must not use zsh's %{{ }} markers",
+    );
+
+    // PowerShell and fish should be byte-for-byte identical: both map to the
+    // bare escape mode internally. Render both against one pre-warmed home so
+    // the comparison isn't thrown off by per-home paths in any notice text.
+    let home = scratch_home("pwsh-vs-fish");
+    let _ = render_in(&home, "pwsh"); // warm the config once
+    assert_eq!(
+        render_in(&home, "pwsh"),
+        render_in(&home, "fish"),
+        "PowerShell and fish should render identical bare-escape output",
+    );
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn each_shell_uses_its_own_escape_style() {
+    let bash = render("bash");
+    assert!(
+        bash.contains("\\[") && bash.contains("\\]"),
+        "bash prompt should wrap escapes in \\[ \\] markers",
+    );
+    assert!(
+        !bash.contains(ESC),
+        "bash prompt should escape ESC as \\e, not emit a raw ESC byte",
+    );
+
+    let zsh = render("zsh");
+    assert!(
+        zsh.contains("%{") && zsh.contains("%}"),
+        "zsh prompt should wrap escapes in %{{ }} markers",
+    );
+    assert!(
+        !zsh.contains("\\["),
+        "zsh prompt should not use bash's \\[ markers",
+    );
+}
+
+/// Returns true when a working `pwsh` is on PATH.
+fn have_pwsh() -> bool {
+    Command::new("pwsh")
+        .arg("-version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// End-to-end: source the generated init snippet inside a real PowerShell, call
+/// the `prompt` function it defines, and confirm it renders a prompt without
+/// error. Skipped (passes) when `pwsh` is not installed.
+#[test]
+fn powershell_prompt_function_renders_end_to_end() {
+    if !have_pwsh() {
+        eprintln!("skipping powershell_prompt_function_renders_end_to_end: pwsh not on PATH");
+        return;
+    }
+
+    let home = scratch_home("e2e");
+    let bin_dir = PathBuf::from(BIN)
+        .parent()
+        .expect("binary has a parent dir")
+        .to_path_buf();
+
+    // Pre-create the default config so the one-time "creating default conf"
+    // notice doesn't land in the captured prompt output.
+    let warm = Command::new(BIN)
+        .args(["show", "pwsh", "-s", "0", "-c", "80"])
+        .env("HOME", &home)
+        .output()
+        .expect("warm up config");
+    assert!(warm.status.success());
+
+    // Load the init snippet, then invoke the prompt function it defines. A
+    // failing native command first proves the exit status is threaded through.
+    let script = r#"
+        $env:PATH = $env:SLBIN + [IO.Path]::PathSeparator + $env:PATH
+        (& superline init pwsh) -join "`n" | Invoke-Expression
+        & sh -c 'exit 7'
+        $out = prompt
+        if ($out -notmatch [char]27) { Write-Error 'no ANSI escapes in prompt'; exit 1 }
+        if ($out -notmatch '48;5;160m') { Write-Error 'failing command did not render a red status segment'; exit 1 }
+        if ($LASTEXITCODE -ne 7) { Write-Error "LASTEXITCODE not preserved: $LASTEXITCODE"; exit 1 }
+        Write-Host 'OK'
+    "#;
+
+    let output = Command::new("pwsh")
+        .args(["-NoProfile", "-Command", script])
+        .env("HOME", &home)
+        .env("SLBIN", &bin_dir)
+        .output()
+        .expect("failed to run pwsh");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(
+        output.status.success() && stdout.contains("OK"),
+        "pwsh prompt end-to-end failed\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary

Brings PowerShell (`pwsh`) to parity with the existing fish/bash/zsh integrations.

- `superline install pwsh`, `superline init pwsh`, and `superline show … pwsh` are all wired up.
- The generated `prompt` function threads through the previous command's **exit status**, the **terminal width**, and the **last command's duration** (from `Get-History`), then restores `$LASTEXITCODE` so the user's value isn't clobbered.
  - `$?` is captured **before** `$LASTEXITCODE` — any statement (even an assignment) resets `$?`, which is the classic gotcha that silently broke status detection.
  - Status maps to the bash/zsh convention: `0` on success, the native exit code on failure, `1` for cmdlet failures with no exit code.
- `pwsh` renders the same **bare ANSI escapes as fish** (PSReadLine parses escapes itself, so no `\[ \]`/`%{ %}` non-printing markers are needed).
- `install pwsh` asks PowerShell for `$PROFILE.CurrentUserCurrentHost`, so the profile path is correct on every platform without relying on `$HOME`. `append_conf` now creates the parent directory and file when they don't exist yet (PowerShell profiles usually don't).
- As with bash, there's no native right-hand prompt; the final prompt row shows only its left side.

## Testing

Verified end-to-end on **macOS with PowerShell 7.5.4**:

- New `tests/shell_rendering.rs`:
  - per-shell escape-style guards (bash `\[ \]`, zsh `%{ %}`, fish/pwsh bare ANSI),
  - `pwsh` output is byte-for-byte identical to `fish`,
  - an end-to-end test that loads the generated snippet in a real `pwsh`, renders the prompt, threads a failing native command's code into the red status segment, and confirms `$LASTEXITCODE` is preserved (skips cleanly when `pwsh` isn't on PATH).
- Manually confirmed `install pwsh` resolves `$PROFILE`, creates `~/.config/powershell`, and the loaded profile defines `prompt`.

A full cross-platform **testing plan** (Windows PowerShell 5.1, PS7 on Windows/Linux/macOS, multiple terminals, functional checklist) lives in [`docs/powershell-testing.md`](docs/powershell-testing.md).

### Known follow-up

PowerShell on **Windows** additionally needs the binary ported off its current Unix-only assumptions (the `users` crate for root/user detection and direct `$HOME` reads). These are pre-existing limitations shared by all shells, not introduced here — the pwsh profile-path detection already avoids `$HOME`. Details and exact call sites are in the testing-plan doc. macOS/Linux pwsh support is complete today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)