### PR TITLE
feat(platform): add Windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,38 @@ jobs:
 
       - name: Test
         run: cargo test --verbose
+
+      # Guard the pure-Rust `git` CLI backend (no libgit2 C build) - the path
+      # recommended for Windows installs without a C toolchain.
+      - name: Test (no default features, git-CLI backend)
+        run: cargo test --no-default-features --verbose
+
+  windows:
+    name: Build & test (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      # Default features build libgit2 from C source; windows-latest ships the
+      # MSVC toolchain + cmake that `cc`/`libgit2-sys` need.
+      - name: Build
+        run: cargo build --verbose
+
+      # Runs the unit tests plus the real-`pwsh` end-to-end prompt test
+      # (PowerShell 7 is preinstalled on windows-latest).
+      - name: Test
+        run: cargo test --verbose
+
+      - name: Build (no default features, git-CLI backend)
+        run: cargo build --no-default-features --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.claude/
 /target/
 **/*.rs.bk
 .DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ repository = "https://github.com/alxhill/superline"
 readme = "README.md"
 
 [dependencies]
-users = "0.11"
-libc = "0.2"
 hostname = "0.3"
 git2 = { version = "0.18", optional = true, default-features = false }
 serde = { version = "1.0.203", features = ["derive"] }
@@ -18,6 +16,13 @@ serde_json = "1.0.117"
 thiserror = "1.0.61"
 clap = { version = "4.5.7", features = ["derive"] }
 chrono = "0.4.38"
+
+# Unix-only: the `users` crate wraps libc's passwd/uid APIs, and `libc::access`
+# powers the read-only check. Windows uses the env-var / std fallbacks in
+# `platform.rs` instead.
+[target.'cfg(unix)'.dependencies]
+users = "0.11"
+libc = "0.2"
 
 [features]
 default = ["libgit"]

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ superline install <shell name>
 
 Then reload your shell's config. Superline will modify the default config file for the shell you choose - currently,
 `fish`, `zsh`, `bash`, and `pwsh` (PowerShell). For example, `superline install pwsh` appends the loader to your
-PowerShell profile (`$PROFILE`), creating it if necessary. PowerShell is not yet tested on Windows.
+PowerShell profile (`$PROFILE`), creating it if necessary. PowerShell compiles for Windows (the Unix-only bits live
+behind `src/platform.rs`) but isn't yet runtime-tested there — see
+[`docs/powershell-testing.md`](docs/powershell-testing.md) for the cross-platform testing plan and Windows caveats.
 
 Cargo's bin directory must be in your `$PATH` for the `superline` command to be available.
-
 
 ## Customization
 

--- a/docs/powershell-testing.md
+++ b/docs/powershell-testing.md
@@ -66,11 +66,18 @@ Run the **functional checklist** below in each configuration.
 | 5 | Windows 10/11 | Windows PowerShell 5.1 | legacy `conhost.exe` | Verify VT processing + glyph fallback. |
 | 6 | macOS | `pwsh` 7+ | iTerm2 / Terminal.app | Sanity re-check on a second terminal. |
 
-> ⚠️ **Windows requires a binary port first.** The crate currently depends on the
-> Unix-only `users` crate and reads `$HOME` directly (see "Known limitations").
-> Until that work lands, configurations 2–5 cannot be built/run on Windows even
-> though the PowerShell integration itself is correct. On macOS/Linux the
-> integration is complete today.
+> ℹ️ **Windows now compiles.** The crate's Unix-only assumptions (the `users`
+> crate, `libc::access`, and direct `$HOME` reads) have been ported behind the
+> cross-platform helpers in `src/platform.rs`, and both `x86_64-pc-windows-gnu`
+> and `x86_64-pc-windows-msvc` pass `cargo check`. The remaining unknown is the
+> runtime behaviour on a real Windows box (configs 2–5), which still needs
+> hands-on verification — that's what this checklist is for.
+>
+> **Building on Windows:** the default `libgit` feature builds `libgit2` from C
+> source, so it needs a C toolchain (the standard MSVC `rustup` setup on Windows
+> provides one). To skip the C build entirely, install with
+> `cargo install superline --no-default-features`, which uses the `git` CLI
+> backend instead (requires `git` on `PATH`).
 
 ## Functional checklist (per configuration)
 
@@ -128,23 +135,40 @@ Checks:
 - [ ] Output encoding is UTF-8 so Nerd Font glyphs aren't mangled
       (`$OutputEncoding` / `chcp 65001` for legacy conhost).
 
+## Windows port — what changed
+
+The Unix-only assumptions are now isolated in `src/platform.rs`, which exposes
+cross-platform helpers used by both the library and the binary:
+
+- `home_dir()` — `$HOME` on Unix, `%USERPROFILE%` (then `%HOMEDRIVE%%HOMEPATH%`)
+  on Windows. Used for the config path (`get_or_create_conf_file`), `~`
+  substitution (`cwd.rs`), and the bash/zsh/fish install paths.
+- `cache_dir()` — `$XDG_CACHE_HOME`/`$HOME/.cache` on Unix, `%LOCALAPPDATA%` on
+  Windows. Used by the PR cache.
+- `is_root()` / `current_username()` — the Unix `users`-crate calls, gated to
+  `#[cfg(unix)]`; on Windows `is_root()` returns `false` and the username comes
+  from `%USERNAME%`.
+- `cwd_is_readonly()` — `libc::access(W_OK)` on Unix; the directory's read-only
+  attribute on Windows.
+
+`users` and `libc` are now `[target.'cfg(unix)'.dependencies]`, so they're never
+built for Windows. `cwd.rs` uses `std::path::MAIN_SEPARATOR` and falls back from
+`$PWD` to `current_dir()`. The directory-resolution rules have unit tests that
+exercise **both** the Unix and Windows branches regardless of host.
+
 ## Known limitations & follow-ups
 
-- **Windows binary port (blocker for configs 2–5).** To build and run on
-  Windows the crate needs:
-  - `users` crate usage replaced with a cross-platform alternative. It's used
-    for root detection in `src/modules/cmd.rs` (`get_current_uid() == 0`) and
-    for the current user name in `src/modules/user.rs`. On Windows, gate these
-    behind `#[cfg(unix)]` and provide a Windows path (e.g. default to
-    non-root / use `USERNAME`, or detect elevation via the Win32 API).
-  - `$HOME` reads replaced with a portable home lookup (`USERPROFILE` on
-    Windows, or the `dirs` crate). Affected: config path in
-    `src/bin/superline.rs` (`get_or_create_conf_file`), `~` substitution in
-    `src/modules/cwd.rs`, and the PR cache dir in `src/modules/pr.rs`
-    (`XDG_CACHE_HOME`/`HOME` → `LOCALAPPDATA` on Windows).
-  These are pre-existing Unix assumptions shared by all shells, not introduced
-  by the PowerShell work; the `pwsh` profile-path detection already avoids
-  `$HOME`.
+- **Elevation detection on Windows.** `is_root()` always reports non-elevated on
+  Windows, so the prompt never shows the root symbol / root-user colour there.
+  Detecting an elevated ("Run as administrator") session needs Win32 token APIs
+  and is left as a future enhancement.
+- **Read-only detection on Windows is best-effort** — it reports the directory's
+  read-only *attribute*, which Windows largely ignores for directories, so the
+  lock icon will rarely appear. True write access is governed by ACLs.
+- **`libgit` feature needs a C toolchain on Windows** (it builds `libgit2` from
+  source). Use `--no-default-features` for the pure-`git`-CLI backend if that's
+  not available. The C cross-build can't be verified from the macOS dev box; a
+  real Windows/MSVC build or CI run should confirm it.
 - **No native right prompt**, matching bash. Right-aligned segments only render
   on non-final rows of a multi-row prompt.
 - **OSC 8 hyperlinks** (PR segment) require a terminal that supports them;

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -1,6 +1,5 @@
 extern crate superline;
 
-use std::env::VarError;
 use std::error::Error;
 use std::fs::{create_dir_all, File, OpenOptions};
 use std::io::Write;
@@ -270,10 +269,10 @@ fn install(args: InstallArgs) {
     println!("Done, please restart your shell for changes to take effect");
 }
 
-/// Resolve a path inside the Unix `$HOME` directory used by the bash/zsh/fish
+/// Resolve a path inside the user's home directory used by the bash/zsh/fish
 /// config files.
 fn home_config(rel: &str) -> PathBuf {
-    let home_dir = PathBuf::from(env::var("HOME").expect("could not read $HOME env var"));
+    let home_dir = superline::platform::home_dir().expect("could not determine home directory");
     assert!(home_dir.is_dir(), "home directory does not exist");
     home_dir.join(rel)
 }
@@ -441,8 +440,8 @@ fn show_normal(args: &ShowArgs, conf: Config, conf_root: PathBuf) {
 
 #[derive(Error, Debug)]
 enum PowerlineError {
-    #[error("could not read value of $HOME env var")]
-    HomeEnvNotFound(#[from] VarError),
+    #[error("could not determine home directory")]
+    HomeDirNotFound,
     #[error("could not read config file")]
     IoError(#[from] io::Error),
     #[error("config file could not be parsed")]
@@ -457,7 +456,7 @@ fn load_config(conf_file: Option<PathBuf>) -> Result<(Config, PathBuf), Powerlin
 }
 
 fn get_or_create_conf_file() -> Result<PathBuf, PowerlineError> {
-    let home_dir = PathBuf::from(env::var("HOME")?);
+    let home_dir = superline::platform::home_dir().ok_or(PowerlineError::HomeDirNotFound)?;
     let config_dir = home_dir.join(".config/superline");
     if !config_dir.exists() {
         create_dir_all(&config_dir)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod colors;
 pub mod config;
 pub mod modules;
+pub mod platform;
 pub mod powerline;
 pub mod terminal;
 pub mod themes;

--- a/src/modules/cmd.rs
+++ b/src/modules/cmd.rs
@@ -49,7 +49,7 @@ impl<S: CmdScheme> Cmd<S> {
 
 impl<S: CmdScheme> Module for Cmd<S> {
     fn append_segments(&mut self, powerline: &mut Powerline) {
-        let user_symbol = if users::get_current_uid() == 0 {
+        let user_symbol = if crate::platform::is_root() {
             S::cmd_root_symbol()
         } else {
             S::cmd_user_symbol()

--- a/src/modules/cwd.rs
+++ b/src/modules/cwd.rs
@@ -1,7 +1,9 @@
 use std::marker::PhantomData;
+use std::path::{MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
 use std::{env, path};
 
 use crate::colors::Color;
+use crate::platform;
 use crate::themes::DefaultColors;
 use crate::{Powerline, Style};
 
@@ -46,34 +48,41 @@ impl<S: CwdScheme> Module for Cwd<S> {
         let current_dir = if self.resolve_symlinks {
             env::current_dir().unwrap()
         } else {
-            path::PathBuf::from(env::var("PWD").unwrap())
+            // $PWD is the shell's logical (symlink-preserving) cwd, but it isn't
+            // set on Windows or by every shell, so fall back to the real cwd.
+            env::var_os("PWD")
+                .map(path::PathBuf::from)
+                .unwrap_or_else(|| env::current_dir().unwrap())
         };
 
-        let mut cwd = current_dir.to_str().unwrap();
+        let current_dir = current_dir.to_string_lossy();
+        let mut cwd: &str = &current_dir;
 
         let mut current_bg = 0usize;
 
+        // Sitting at the filesystem root ("/" on Unix) - just show the glyph.
         #[allow(unused_assignments)]
-        if cwd == "/" {
+        if cwd == MAIN_SEPARATOR_STR {
             rainbow_segment!(powerline, current_bg, "~");
             return;
         }
 
-        if let Ok(home_str) = env::var("HOME") {
-            if cwd.starts_with(&home_str) {
+        if let Some(home) = platform::home_dir() {
+            let home = home.to_string_lossy();
+            if cwd.starts_with(home.as_ref()) {
                 rainbow_segment!(powerline, current_bg, "~");
-                cwd = &cwd[home_str.len()..]
+                cwd = &cwd[home.len()..]
             }
         }
 
-        let depth = cwd.matches('/').count();
+        let depth = cwd.matches(MAIN_SEPARATOR).count();
 
         if (cwd.len() > self.max_length) && (depth > self.wanted_seg_num) {
             let left = self.wanted_seg_num / 2;
             let right = self.wanted_seg_num - left;
 
-            let start = cwd.split('/').skip(1).take(left);
-            let end = cwd.split('/').skip(depth - right + 1);
+            let start = cwd.split(MAIN_SEPARATOR).skip(1).take(left);
+            let end = cwd.split(MAIN_SEPARATOR).skip(depth - right + 1);
 
             for val in start {
                 rainbow_segment!(powerline, current_bg, val);
@@ -85,7 +94,7 @@ impl<S: CwdScheme> Module for Cwd<S> {
                 rainbow_segment!(powerline, current_bg, val);
             }
         } else {
-            for val in cwd.split('/').skip(1) {
+            for val in cwd.split(MAIN_SEPARATOR).skip(1) {
                 rainbow_segment!(powerline, current_bg, val);
             }
         };

--- a/src/modules/git/process.rs
+++ b/src/modules/git/process.rs
@@ -5,7 +5,7 @@ use super::GitStats;
 
 pub fn get_first_number(s: &str) -> u32 {
     s.chars()
-        .take_while(|x| x.is_digit(10))
+        .take_while(|x| x.is_ascii_digit())
         .flat_map(|x| x.to_digit(10))
         .fold(0, |acc, x| 10 * acc + x)
 }
@@ -51,7 +51,7 @@ pub fn get_branch_name(s: &str) -> Option<&str> {
 
 pub fn get_detached_branch_name() -> String {
     let child = Command::new("git")
-        .args(&["describe", "--tags", "--always"])
+        .args(["describe", "--tags", "--always"])
         .output()
         .unwrap();
 
@@ -69,13 +69,17 @@ pub fn get_detached_branch_name() -> String {
 
 pub fn run_git(_: &Path) -> GitStats {
     let output = Command::new("git")
-        .args(&["status", "--porcelain", "-b"])
+        .args(["status", "--porcelain", "-b"])
         .output()
         .unwrap()
         .stdout;
 
     let mut lines = output.split(|x| *x == (b'\n'));
     let branch_line = std::str::from_utf8(lines.next().unwrap()).unwrap();
+
+    // `git status -b --porcelain` renders an upstream as `## local...remote`, so
+    // the `...` separator tells us whether the branch is tracking a remote.
+    let remote = branch_line.contains("...");
 
     let mut ahead = 0;
     let mut behind = 0;
@@ -85,7 +89,7 @@ pub fn run_git(_: &Path) -> GitStats {
     let mut untracked = 0;
 
     let branch_name = {
-        if let Some(branch_name) = get_branch_name(&branch_line) {
+        if let Some(branch_name) = get_branch_name(branch_line) {
             if let Some(info) = branch_line
                 .find('[')
                 .map(|pos| branch_line.get(pos..).unwrap())
@@ -127,6 +131,7 @@ pub fn run_git(_: &Path) -> GitStats {
         non_staged,
         staged,
         conflicted,
+        remote,
         branch_name,
     }
 }

--- a/src/modules/pr.rs
+++ b/src/modules/pr.rs
@@ -229,9 +229,7 @@ fn current_branch_and_root() -> Option<(String, PathBuf)> {
 }
 
 fn cache_path_for(repo_root: &Path, branch: &str) -> Option<PathBuf> {
-    let base = env::var_os("XDG_CACHE_HOME")
-        .map(PathBuf::from)
-        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))?;
+    let base = crate::platform::cache_dir()?;
 
     let mut hasher = DefaultHasher::new();
     repo_root.hash(&mut hasher);

--- a/src/modules/readonly.rs
+++ b/src/modules/readonly.rs
@@ -1,9 +1,8 @@
-use std::ffi::CString;
 use std::marker::PhantomData;
 
 use crate::colors::Color;
 use crate::themes::DefaultColors;
-use crate::{Powerline, Style};
+use crate::{platform, Powerline, Style};
 
 use super::Module;
 
@@ -36,12 +35,7 @@ impl<S: ReadOnlyScheme> ReadOnly<S> {
 
 impl<S: ReadOnlyScheme> Module for ReadOnly<S> {
     fn append_segments(&mut self, powerline: &mut Powerline) {
-        let readonly = unsafe {
-            let path = CString::new("./").unwrap();
-            libc::access(path.as_ptr(), libc::W_OK) != 0
-        };
-
-        if readonly {
+        if platform::cwd_is_readonly() {
             powerline.add_segment(
                 S::readonly_symbol(),
                 Style::simple(S::readonly_fg(), S::readonly_bg()),

--- a/src/modules/user.rs
+++ b/src/modules/user.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::colors::Color;
 use crate::themes::DefaultColors;
-use crate::{utils, Powerline, Style};
+use crate::{platform, utils, Powerline, Style};
 
 use super::Module;
 
@@ -48,17 +48,15 @@ impl<S: UserScheme> User<S> {
 impl<S: UserScheme> Module for User<S> {
     fn append_segments(&mut self, powerline: &mut Powerline) {
         if self.show_on_local || utils::is_remote_shell() {
-            let user = users::get_user_by_uid(users::get_current_uid()).unwrap();
-            let bg = if user.uid() == 0 {
+            let bg = if platform::is_root() {
                 S::username_root_bg()
             } else {
                 S::username_bg()
             };
 
-            powerline.add_segment(
-                user.name().to_str().unwrap(),
-                Style::simple(S::username_fg(), bg),
-            );
+            if let Some(name) = platform::current_username() {
+                powerline.add_segment(name, Style::simple(S::username_fg(), bg));
+            }
         }
     }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,216 @@
+//! Small cross-platform helpers that paper over the differences between Unix
+//! and Windows for the handful of OS-specific things the prompt needs: the
+//! home/cache directories, the current user, root/elevation, and whether the
+//! current directory is writable.
+//!
+//! The directory lookups are split into a pure resolver (which takes an
+//! environment-variable getter and a `windows` flag) and a thin public wrapper
+//! that feeds it the real environment. That lets the tests exercise both the
+//! Unix and Windows resolution rules regardless of the host they run on.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+/// A function that looks up an environment variable, mirroring
+/// [`std::env::var_os`]. Taken as a parameter so tests can inject a fake
+/// environment.
+type EnvGetter<'a> = dyn Fn(&str) -> Option<OsString> + 'a;
+
+fn real_env(key: &str) -> Option<OsString> {
+    std::env::var_os(key)
+}
+
+/// Resolve the user's home directory from the given environment.
+///
+/// * Unix: `$HOME`.
+/// * Windows: `%USERPROFILE%`, falling back to `%HOMEDRIVE%%HOMEPATH%`.
+fn resolve_home(env: &EnvGetter, windows: bool) -> Option<PathBuf> {
+    let non_empty = |v: OsString| (!v.is_empty()).then_some(v);
+
+    if windows {
+        if let Some(profile) = env("USERPROFILE").and_then(non_empty) {
+            return Some(PathBuf::from(profile));
+        }
+        // `%HOMEDRIVE%%HOMEPATH%` is a plain concatenation (e.g. `C:` + `\Users\x`),
+        // so join the strings directly rather than via `PathBuf::push`, which
+        // would insert the host's separator.
+        let mut home = env("HOMEDRIVE").and_then(non_empty)?;
+        home.push(env("HOMEPATH").and_then(non_empty)?);
+        Some(PathBuf::from(home))
+    } else {
+        env("HOME").and_then(non_empty).map(PathBuf::from)
+    }
+}
+
+/// Resolve the cache directory from the given environment.
+///
+/// * Unix: `$XDG_CACHE_HOME`, falling back to `$HOME/.cache`.
+/// * Windows: `%LOCALAPPDATA%`, falling back to `<home>/.cache`.
+fn resolve_cache(env: &EnvGetter, home: Option<PathBuf>, windows: bool) -> Option<PathBuf> {
+    let non_empty = |v: OsString| (!v.is_empty()).then_some(v);
+
+    let explicit = if windows {
+        "LOCALAPPDATA"
+    } else {
+        "XDG_CACHE_HOME"
+    };
+    if let Some(dir) = env(explicit).and_then(non_empty) {
+        return Some(PathBuf::from(dir));
+    }
+    home.map(|h| h.join(".cache"))
+}
+
+/// The current user's home directory, or `None` if it can't be determined.
+pub fn home_dir() -> Option<PathBuf> {
+    resolve_home(&real_env, cfg!(windows))
+}
+
+/// The base cache directory superline should use, or `None` if it can't be
+/// determined.
+pub fn cache_dir() -> Option<PathBuf> {
+    resolve_cache(&real_env, home_dir(), cfg!(windows))
+}
+
+/// Whether the current process is running as root (Unix) / is the closest
+/// equivalent on other platforms.
+///
+/// On Windows there is no uid; the prompt simply treats the session as
+/// non-elevated (showing the normal user symbol). Detecting an elevated
+/// "Run as administrator" session would require Win32 token APIs and is left as
+/// a future enhancement.
+#[cfg(unix)]
+pub fn is_root() -> bool {
+    users::get_current_uid() == 0
+}
+
+#[cfg(not(unix))]
+pub fn is_root() -> bool {
+    false
+}
+
+/// The current user's login name.
+#[cfg(unix)]
+pub fn current_username() -> Option<String> {
+    users::get_user_by_uid(users::get_current_uid())
+        .map(|user| user.name().to_string_lossy().into_owned())
+}
+
+#[cfg(not(unix))]
+pub fn current_username() -> Option<String> {
+    std::env::var("USERNAME")
+        .ok()
+        .or_else(|| std::env::var("USER").ok())
+}
+
+/// Whether the current working directory is not writable by this process.
+#[cfg(unix)]
+pub fn cwd_is_readonly() -> bool {
+    use std::ffi::CString;
+    // `access(W_OK)` answers the real question - can we write here - taking the
+    // effective uid and directory permissions into account.
+    let path = CString::new("./").expect("static path is valid");
+    unsafe { libc::access(path.as_ptr(), libc::W_OK) != 0 }
+}
+
+#[cfg(windows)]
+pub fn cwd_is_readonly() -> bool {
+    // Best effort on Windows: the directory's read-only attribute. Real write
+    // access is governed by ACLs that this doesn't fully capture, but it matches
+    // the common case and never blocks the prompt.
+    std::fs::metadata(".")
+        .map(|m| m.permissions().readonly())
+        .unwrap_or(false)
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn cwd_is_readonly() -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build an [`EnvGetter`] backed by a fixed map, so resolution can be tested
+    /// independently of the host's real environment.
+    fn fake_env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<OsString> + 'a {
+        let map: HashMap<&str, &str> = vars.iter().copied().collect();
+        move |key| map.get(key).map(OsString::from)
+    }
+
+    #[test]
+    fn home_uses_home_on_unix() {
+        let env = fake_env(&[("HOME", "/home/alex"), ("USERPROFILE", r"C:\Users\alex")]);
+        assert_eq!(resolve_home(&env, false), Some(PathBuf::from("/home/alex")));
+    }
+
+    #[test]
+    fn home_uses_userprofile_on_windows() {
+        let env = fake_env(&[("HOME", "/home/alex"), ("USERPROFILE", r"C:\Users\alex")]);
+        assert_eq!(
+            resolve_home(&env, true),
+            Some(PathBuf::from(r"C:\Users\alex"))
+        );
+    }
+
+    #[test]
+    fn home_falls_back_to_homedrive_homepath_on_windows() {
+        let env = fake_env(&[("HOMEDRIVE", "C:"), ("HOMEPATH", r"\Users\alex")]);
+        assert_eq!(
+            resolve_home(&env, true),
+            Some(PathBuf::from(r"C:\Users\alex"))
+        );
+    }
+
+    #[test]
+    fn home_is_none_when_nothing_is_set() {
+        let env = fake_env(&[]);
+        assert_eq!(resolve_home(&env, false), None);
+        assert_eq!(resolve_home(&env, true), None);
+    }
+
+    #[test]
+    fn empty_values_are_ignored() {
+        let env = fake_env(&[("HOME", ""), ("USERPROFILE", "")]);
+        assert_eq!(resolve_home(&env, false), None);
+        assert_eq!(resolve_home(&env, true), None);
+    }
+
+    #[test]
+    fn cache_prefers_xdg_on_unix() {
+        let env = fake_env(&[("XDG_CACHE_HOME", "/xdg/cache")]);
+        assert_eq!(
+            resolve_cache(&env, Some(PathBuf::from("/home/alex")), false),
+            Some(PathBuf::from("/xdg/cache"))
+        );
+    }
+
+    #[test]
+    fn cache_falls_back_to_home_dot_cache_on_unix() {
+        let env = fake_env(&[]);
+        assert_eq!(
+            resolve_cache(&env, Some(PathBuf::from("/home/alex")), false),
+            Some(PathBuf::from("/home/alex/.cache"))
+        );
+    }
+
+    #[test]
+    fn cache_prefers_localappdata_on_windows() {
+        let env = fake_env(&[("LOCALAPPDATA", r"C:\Users\alex\AppData\Local")]);
+        assert_eq!(
+            resolve_cache(&env, Some(PathBuf::from(r"C:\Users\alex")), true),
+            Some(PathBuf::from(r"C:\Users\alex\AppData\Local"))
+        );
+    }
+
+    #[test]
+    fn cache_ignores_xdg_on_windows() {
+        // XDG_CACHE_HOME must not leak into Windows resolution.
+        let env = fake_env(&[("XDG_CACHE_HOME", "/xdg/cache")]);
+        assert_eq!(
+            resolve_cache(&env, Some(PathBuf::from(r"C:\Users\alex")), true),
+            Some(PathBuf::from(r"C:\Users\alex").join(".cache"))
+        );
+    }
+}

--- a/tests/default_config.rs
+++ b/tests/default_config.rs
@@ -28,7 +28,10 @@ fn default_config_parses_with_compiled_binary() {
 
     let output = Command::new(BIN)
         .args(["show", "fish", "-s", "0", "-c", "80"])
+        // Point the binary's home lookup at the scratch dir on both Unix ($HOME)
+        // and Windows (%USERPROFILE%).
         .env("HOME", &home)
+        .env("USERPROFILE", &home)
         .output()
         .expect("failed to run the powerline binary");
 

--- a/tests/shell_rendering.rs
+++ b/tests/shell_rendering.rs
@@ -32,7 +32,9 @@ fn scratch_home(label: &str) -> PathBuf {
 fn render_in(home: &PathBuf, shell: &str) -> String {
     let output = Command::new(BIN)
         .args(["show", shell, "-s", "0", "-c", "80"])
+        // Home lookup keys off $HOME on Unix and %USERPROFILE% on Windows.
         .env("HOME", home)
+        .env("USERPROFILE", home)
         .output()
         .expect("failed to run the superline binary");
     assert!(
@@ -139,26 +141,36 @@ fn powershell_prompt_function_renders_end_to_end() {
     let warm = Command::new(BIN)
         .args(["show", "pwsh", "-s", "0", "-c", "80"])
         .env("HOME", &home)
+        .env("USERPROFILE", &home)
         .output()
         .expect("warm up config");
     assert!(warm.status.success());
 
-    // Load the init snippet, then invoke the prompt function it defines. A
-    // failing native command first proves the exit status is threaded through.
+    // A native command that exits non-zero, to prove the status is threaded
+    // through. `sh` may be absent on Windows, so use `cmd` there.
+    let fail_cmd = if cfg!(windows) {
+        "cmd /c exit 7"
+    } else {
+        "& sh -c 'exit 7'"
+    };
+
+    // Load the init snippet, then invoke the prompt function it defines.
     let script = r#"
         $env:PATH = $env:SLBIN + [IO.Path]::PathSeparator + $env:PATH
         (& superline init pwsh) -join "`n" | Invoke-Expression
-        & sh -c 'exit 7'
+        __FAILCMD__
         $out = prompt
         if ($out -notmatch [char]27) { Write-Error 'no ANSI escapes in prompt'; exit 1 }
         if ($out -notmatch '48;5;160m') { Write-Error 'failing command did not render a red status segment'; exit 1 }
         if ($LASTEXITCODE -ne 7) { Write-Error "LASTEXITCODE not preserved: $LASTEXITCODE"; exit 1 }
         Write-Host 'OK'
-    "#;
+    "#
+    .replace("__FAILCMD__", fail_cmd);
 
     let output = Command::new("pwsh")
-        .args(["-NoProfile", "-Command", script])
+        .args(["-NoProfile", "-Command", &script])
         .env("HOME", &home)
+        .env("USERPROFILE", &home)
         .env("SLBIN", &bin_dir)
         .output()
         .expect("failed to run pwsh");


### PR DESCRIPTION
> **Stacked on #17** (`ah/powershell-support`). Review/merge that first — this PR targets `ah/powershell-support`, not `main`, so the diff is just the Windows work.

## Summary

Makes the binary compile and run on Windows by isolating every Unix-only assumption behind a new cross-platform `src/platform.rs` module. This is the follow-up flagged in #17's testing plan.

### What moved behind `platform`
| Helper | Unix | Windows |
|--------|------|---------|
| `home_dir()` | `$HOME` | `%USERPROFILE%` → `%HOMEDRIVE%%HOMEPATH%` |
| `cache_dir()` | `$XDG_CACHE_HOME` / `$HOME/.cache` | `%LOCALAPPDATA%` |
| `current_username()` | `users` crate | `%USERNAME%` |
| `is_root()` | `uid == 0` | `false` (non-elevated) |
| `cwd_is_readonly()` | `libc::access(W_OK)` | read-only attribute |

- `users` + `libc` are now `[target.'cfg(unix)'.dependencies]` (they don't even compile for Windows), and `cmd.rs` / `user.rs` / `readonly.rs` route through `platform`.
- `cwd.rs` uses `std::path::MAIN_SEPARATOR` and falls back from `$PWD` to `current_dir()`; `pr.rs` and the binary's config/home paths use the helpers.
- The directory-resolution rules are split into **pure resolver fns unit-tested for both the Unix and Windows branches regardless of host** — which caught a real bug (joining `%HOMEDRIVE%%HOMEPATH%` via `PathBuf::push` inserts the host separator; fixed with `OsString` concatenation).

### Process git backend fix
The `process` backend (used by `--no-default-features`, the C-toolchain-free path that's attractive on Windows) didn't compile: it was missing the `GitStats.remote` field. Derived it from the `## local...remote` upstream marker in `git status -b --porcelain`, and cleared the stale clippy lints so that build is warning-free too.

## Testing

- ✅ `cargo check --no-default-features` passes for **both** `x86_64-pc-windows-gnu` and `x86_64-pc-windows-msvc` (verified from the macOS dev box).
- ✅ Default-feature build, `cargo clippy --all-targets -D warnings`, and the full test suite stay green on Unix — for **both** the `libgit` and `process` backends.
- ✅ 8 new unit tests in `platform.rs` cover Unix + Windows home/cache resolution.

### Caveats (documented in `docs/powershell-testing.md`)
- The `libgit` default feature builds `libgit2` from C, so a Windows build needs the MSVC toolchain — or `cargo install superline --no-default-features` for the `git`-CLI backend. The C cross-build can't be verified from macOS; a real Windows/MSVC build should confirm it.
- `is_root()` and read-only detection are best-effort on Windows (no elevation/ACL inspection).
- Runtime behaviour on a real Windows box still wants the hands-on checklist in the testing-plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)