### PR TITLE
fix(platform): link advapi32 on Windows for the libgit2 backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,32 +70,19 @@ jobs:
       - name: Build (no default features, git-CLI backend)
         run: cargo build --no-default-features --verbose
 
-  windows-latest-deps:
-    name: Build (Windows, latest deps)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-
-      # `cargo install` resolves dependencies fresh instead of using the
-      # committed Cargo.lock, so a published release can pull newer transitive
-      # crates than the locked build above ever sees. That is exactly how the
-      # advapi32 link failure shipped: libgit2-sys never links advapi32, and the
-      # locked build only succeeds because the pinned windows-sys 0.52 (via
+      # The steps above build the committed Cargo.lock. `cargo install` instead
+      # resolves dependencies fresh, so a published release can pull newer
+      # transitive crates than the locked build ever sees. That is exactly how
+      # the advapi32 link failure shipped: libgit2-sys never links advapi32, and
+      # the locked build only succeeds because the pinned windows-sys 0.52 (via
       # chrono) drags its umbrella Win32 import library onto the link line and
       # incidentally resolves those symbols. Newer windows-sys uses per-function
-      # raw-dylib imports and drops that coverage. Resolving to the latest
-      # compatible versions here mirrors the `cargo install` view and fails
-      # loudly if a transitive bump removes a system library we depend on.
+      # raw-dylib imports and drops that coverage. Resolve to the latest
+      # compatible versions and rebuild so this job also mirrors the
+      # `cargo install` view and fails loudly if a transitive bump removes a
+      # system library we depend on. Kept last because it rewrites Cargo.lock.
       - name: Update to latest compatible dependencies
         run: cargo update
 
-      # Default features build the libgit2 backend, where the missing advapi32
-      # link surfaces.
-      - name: Build
+      - name: Build (latest deps)
         run: cargo build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,33 @@ jobs:
 
       - name: Build (no default features, git-CLI backend)
         run: cargo build --no-default-features --verbose
+
+  windows-latest-deps:
+    name: Build (Windows, latest deps)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      # `cargo install` resolves dependencies fresh instead of using the
+      # committed Cargo.lock, so a published release can pull newer transitive
+      # crates than the locked build above ever sees. That is exactly how the
+      # advapi32 link failure shipped: libgit2-sys never links advapi32, and the
+      # locked build only succeeds because the pinned windows-sys 0.52 (via
+      # chrono) drags its umbrella Win32 import library onto the link line and
+      # incidentally resolves those symbols. Newer windows-sys uses per-function
+      # raw-dylib imports and drops that coverage. Resolving to the latest
+      # compatible versions here mirrors the `cargo install` view and fails
+      # loudly if a transitive bump removes a system library we depend on.
+      - name: Update to latest compatible dependencies
+        run: cargo update
+
+      # Default features build the libgit2 backend, where the missing advapi32
+      # link surfaces.
+      - name: Build
+        run: cargo build --verbose

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    // libgit2-sys 0.16.2 (bundling libgit2 1.7.2) compiles libgit2's Windows
+    // backends — rand.c, sysdir.c and fs_path.c — which call CryptGenRandom,
+    // the Reg* registry APIs and the token/SID security APIs. Those all live in
+    // advapi32, but libgit2-sys's build script never emits a link directive for
+    // it (it only links winhttp, rpcrt4, ole32, crypt32 and secur32). On the
+    // MSVC toolchain that leaves the final link with unresolved __imp_Crypt*,
+    // __imp_Reg* and __imp_*Sid externals. Supply the missing dependency here,
+    // but only when we actually pull in libgit2 (the `git2` optional dep, which
+    // the `libgit` feature turns on).
+    let target_windows = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
+    let libgit2_in_build = std::env::var_os("CARGO_FEATURE_GIT2").is_some();
+    if target_windows && libgit2_in_build {
+        println!("cargo:rustc-link-lib=advapi32");
+    }
+}


### PR DESCRIPTION
## Problem

The Windows build fails at link time with 15 unresolved externals, e.g. on a fresh `cargo install superline`:

```
liblibgit2_sys-*.rlib(...-rand.o) : error LNK2019: unresolved external symbol __imp_CryptGenRandom ...
liblibgit2_sys-*.rlib(...-sysdir.o) : error LNK2019: unresolved external symbol __imp_RegOpenKeyExW ...
liblibgit2_sys-*.rlib(...-fs_path.o) : error LNK2019: unresolved external symbol __imp_GetNamedSecurityInfoW ...
fatal error LNK1120: 15 unresolved externals
```

## Root cause

All 15 symbols (`Crypt*`, `Reg*`, `OpenProcessToken`, `CheckTokenMembership`, `GetNamedSecurityInfoW`, `GetTokenInformation`, the `*Sid` helpers) are exports of **`advapi32.lib`**. They come from three libgit2 source files that `libgit2-sys 0.16.2+1.7.2` compiles on Windows — `rand.c`, `sysdir.c`, `fs_path.c` — but that crate's build script only links `winhttp`, `rpcrt4`, `ole32`, `crypt32` and `secur32`. It **never emits `advapi32`**.

The build has been passing only by accident: the committed `Cargo.lock` pins `windows-sys 0.52` (pulled transitively via `chrono`), whose single *umbrella* Win32 import library lands on the link line and incidentally resolves those advapi32 symbols. Newer `windows-sys` / `windows-targets 0.53+` switched to per-function `raw-dylib` imports, which only cover explicitly-declared APIs — so that incidental coverage disappears and the link breaks. A fresh `cargo install` resolves the newer `windows-sys` and hits the failure.

## Fix

Add a `build.rs` that links `advapi32` explicitly, gated on Windows targets **and** the `git2` optional dependency (so `--no-default-features` and non-Windows builds are untouched). This removes the reliance on incidental transitive coverage.

## Validation

- Confirmed `superline`'s build output now emits `cargo:rustc-link-lib=advapi32`.
- `cargo build` (debug) and `cargo build --release` (the LTO + `panic=abort` profile that failed) both link.

## Note on CI

The `windows-latest` CI job builds with default features but checks out the committed `Cargo.lock` (windows-sys 0.52), so it links incidentally and stays green — which is why this slipped into a release. Consider adding a `cargo update` step (or a `--locked=false` install smoke test) on the Windows job to catch this class of regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)