### PR TITLE
feat(shell): fix powershell utf8 rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(shell)* set `[Console]::OutputEncoding` to UTF-8 in the PowerShell init so
+  Nerd Font glyphs and powerline separators aren't mangled into mojibake (e.g.
+  `εé░`) when PowerShell decodes superline's output using the legacy OEM code page.
+
 ## [0.5.3](https://github.com/alxhill/superline/compare/v0.5.2...v0.5.3) - 2026-06-16
 
 ### Added

--- a/docs/powershell-testing.md
+++ b/docs/powershell-testing.md
@@ -144,8 +144,11 @@ Checks:
 - [ ] Re-running `superline install pwsh` is idempotent: it detects the existing
       loader in the resolved profile and reports "already installed" instead of
       appending a duplicate block (use `--force` to append anyway).
-- [ ] Output encoding is UTF-8 so Nerd Font glyphs aren't mangled
-      (`$OutputEncoding` / `chcp 65001` for legacy conhost).
+- [ ] Output encoding is UTF-8 so Nerd Font glyphs aren't mangled. The pwsh init
+      now sets `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8` itself
+      (PowerShell decodes a native command's stdout with that encoding, and on
+      Windows it defaults to the legacy OEM code page, which mangles glyphs into
+      mojibake like `εé░`). Legacy conhost may additionally need `chcp 65001`.
 
 ## Windows port — what changed
 

--- a/src/bin/superline.rs
+++ b/src/bin/superline.rs
@@ -88,6 +88,15 @@ source <(superline init bash)
 const PWSH_CONF: &str = r#"
 $env:SUPERLINE_PWSH = 1
 
+# superline emits UTF-8: powerline separators and Nerd Font icons live in the
+# Unicode private-use area. PowerShell decodes a native command's stdout using
+# [Console]::OutputEncoding, which on Windows defaults to the legacy OEM code
+# page - so the bytes get re-read as that code page and the glyphs turn to
+# mojibake (e.g. the U+E0B0 separator shows as "ee 82 b0" decoded to "εé░").
+# Force UTF-8 so the captured output decodes correctly. Wrapped in try/catch
+# for hosts without a real console (remoting, redirected output, some IDEs).
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
+
 function global:prompt {
     # Capture command state first: every statement below (even an assignment)
     # resets $?, so read it before anything else - including before reading

--- a/tests/shell_rendering.rs
+++ b/tests/shell_rendering.rs
@@ -111,6 +111,27 @@ fn each_shell_uses_its_own_escape_style() {
     );
 }
 
+/// The pwsh init must force the console to decode superline's UTF-8 output as
+/// UTF-8. Without this, PowerShell decodes a native command's stdout using the
+/// legacy OEM code page on Windows and mangles Nerd Font glyphs into mojibake
+/// (the U+E0B0 separator shows up as `εé░`). This pins the directive so it can't
+/// silently drop out of the generated snippet.
+#[test]
+fn powershell_init_forces_utf8_output_encoding() {
+    let output = Command::new(BIN)
+        .args(["init", "pwsh"])
+        .output()
+        .expect("failed to run `superline init pwsh`");
+    assert!(output.status.success(), "`init pwsh` exited with failure");
+    let init = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        init.contains("[Console]::OutputEncoding")
+            && init.contains("[System.Text.Encoding]::UTF8"),
+        "pwsh init must set [Console]::OutputEncoding to UTF-8 so Nerd Font \
+         glyphs aren't mangled; got:\n{init}",
+    );
+}
+
 /// Returns true when a working `pwsh` is on PATH.
 fn have_pwsh() -> bool {
     Command::new("pwsh")

--- a/tests/shell_rendering.rs
+++ b/tests/shell_rendering.rs
@@ -125,8 +125,7 @@ fn powershell_init_forces_utf8_output_encoding() {
     assert!(output.status.success(), "`init pwsh` exited with failure");
     let init = String::from_utf8_lossy(&output.stdout);
     assert!(
-        init.contains("[Console]::OutputEncoding")
-            && init.contains("[System.Text.Encoding]::UTF8"),
+        init.contains("[Console]::OutputEncoding") && init.contains("[System.Text.Encoding]::UTF8"),
         "pwsh init must set [Console]::OutputEncoding to UTF-8 so Nerd Font \
          glyphs aren't mangled; got:\n{init}",
     );


### PR DESCRIPTION
## Problem

On Windows, the PowerShell prompt rendered garbled text instead of powerline separators and Nerd Font icons — e.g. the `` separator (`U+E0B0`) showed up as `εé░` and an icon as `∩äà`, even in Windows Terminal with a Nerd Font.

## Root cause

`superline` emits UTF-8: the powerline separator is `U+E0B0` (bytes `EE 82 B0`) and the Nerd Font glyphs live in the Unicode private-use area. The pwsh prompt function captures `& superline …`, and **PowerShell decodes a native command's stdout using `[Console]::OutputEncoding`**, which on Windows defaults to the legacy OEM code page (CP437/850), not UTF-8.

Decoding `EE 82 B0` through CP437 yields exactly `εé░`; `EF 84 85` yields `∩äà`. The corruption happens inside PowerShell at decode time, before the bytes ever reach the terminal — so it's independent of the terminal/font.

## Fix

Set `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8` once in the generated pwsh init (`PWSH_CONF`), wrapped in `try/catch` for hosts without a real console (remoting, redirected output, some IDEs). This matches the approach used by Starship and oh-my-posh.

Verified end-to-end: with the console forced to CP437, the old init produces `ε…`/no real separator; the fixed init emits the real `U+E0B0` separator with the mojibake gone and `[Console]::OutputEncoding` flipped to `utf-8`.

## Changes

- `src/bin/superline.rs` — emit the UTF-8 encoding directive in the pwsh init.
- `tests/shell_rendering.rs` — regression test pinning the directive in `superline init pwsh` output.
- `CHANGELOG.md`, `docs/powershell-testing.md` — document the fix.

## Note for existing users

The directive runs at shell startup, so an already-open session that loaded the old init must be restarted to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)