### PR TITLE
feat(config): sync default config with recommended setup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -78,29 +78,35 @@ impl Default for Config {
             rows: vec![
                 CommandLine {
                     left: vec![
-                        LineSegment::SmallSpacer,
+                        LineSegment::Padding(2),
+                        LineSegment::Separator(SeparatorStyle::Round),
                         LineSegment::ReadOnly,
                         LineSegment::Cwd {
                             max_length: 60,
                             wanted_seg_num: 5,
                             resolve_symlinks: false,
                         },
-                        LineSegment::SmallSpacer,
+                        LineSegment::Padding(2),
                         LineSegment::Git,
+                        LineSegment::Pr { status: true },
                     ],
-                    right: Some(vec![
-                        LineSegment::Separator(SeparatorStyle::Round),
-                        LineSegment::Cargo,
-                        LineSegment::PythonEnv,
-                        LineSegment::Padding(0),
-                    ]),
+                    right: Some(vec![]),
                 },
                 CommandLine {
                     left: vec![
-                        LineSegment::LastCmdDuration { min_run_time: 5 },
+                        LineSegment::Shell,
+                        LineSegment::LastCmdDuration { min_run_time: 50 },
                         LineSegment::Cmd,
+                        LineSegment::Padding(1),
                     ],
-                    right: None,
+                    right: Some(vec![
+                        LineSegment::Separator(SeparatorStyle::Round),
+                        LineSegment::Nvm,
+                        LineSegment::Sdkman,
+                        LineSegment::PythonEnv,
+                        LineSegment::Cargo,
+                        LineSegment::Padding(0),
+                    ]),
                 },
             ],
         }

--- a/tests/shell_rendering.rs
+++ b/tests/shell_rendering.rs
@@ -75,14 +75,18 @@ fn powershell_uses_bare_ansi_like_fish() {
         "PowerShell prompt must not use zsh's %{{ }} markers",
     );
 
-    // PowerShell and fish should be byte-for-byte identical: both map to the
-    // bare escape mode internally. Render both against one pre-warmed home so
-    // the comparison isn't thrown off by per-home paths in any notice text.
+    // PowerShell and fish both map to the same bare-escape mode internally, so
+    // their output is identical except for the one place the default config
+    // prints the shell's own name (the `shell` segment). Normalise that token
+    // out of each and the rest must match byte-for-byte. Render both against one
+    // pre-warmed home so the comparison isn't thrown off by per-home paths in
+    // any notice text.
     let home = scratch_home("pwsh-vs-fish");
     let _ = render_in(&home, "pwsh"); // warm the config once
+    let pwsh_render = render_in(&home, "pwsh").replace("pwsh", "<shell>");
+    let fish_render = render_in(&home, "fish").replace("fish", "<shell>");
     assert_eq!(
-        render_in(&home, "pwsh"),
-        render_in(&home, "fish"),
+        pwsh_render, fish_render,
         "PowerShell and fish should render identical bare-escape output",
     );
     let _ = fs::remove_dir_all(&home);


### PR DESCRIPTION
## What

Updates the hardcoded `Config::default()` in `src/config.rs` — the config written to `~/.config/superline/config.json` on first run — to match the current recommended segment layout.

### Before

- Row 1 (left): `small_spacer`, `read_only`, `cwd`, `small_spacer`, `git`; (right): `python_env`, `cargo`
- Row 2 (left): `last_cmd_duration` (5ms), `cmd`

### After

- Row 1 (left): `padding(2)`, round separator, `read_only`, `cwd`, `padding(2)`, `git`, `pr` (with CI status); (right): empty
- Row 2 (left): `shell`, `last_cmd_duration` (50ms), `cmd`, `padding(1)`; (right): round separator, `nvm`, `sdkman`, `python_env`, `cargo`, `padding(0)`

This brings the segment layout in line with `example_config.json`, which already matched this setup.

## Notes

- The `theme` field is kept as the built-in `"rainbow"` rather than pointing at a custom theme file, so a fresh install renders correctly without any extra files.
- The `default_config_round_trips` test still passes, confirming the serialized default deserializes losslessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)