### PR TITLE
fix(cwd): show current dir under Git Bash on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(cwd)* show the current directory under Git Bash on Windows. The native
+  Windows binary was reading the MSYS-style `$PWD` (e.g. `/c/Users/alex`) and
+  splitting it on `\`, so the whole path collapsed into one segment that the
+  leading `skip(1)` discarded, leaving the module empty. On Windows the cwd is
+  now always taken from the real working directory, which yields a proper
+  `C:\...` path.
+
 ## [0.5.4](https://github.com/alxhill/superline/compare/v0.5.3...v0.5.4) - 2026-06-23
 
 ### Added

--- a/src/modules/cwd.rs
+++ b/src/modules/cwd.rs
@@ -1,6 +1,7 @@
+use std::ffi::OsString;
 use std::marker::PhantomData;
-use std::path::{MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
-use std::{env, path};
+use std::path::{PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
+use std::env;
 
 use crate::colors::Color;
 use crate::platform;
@@ -43,17 +44,37 @@ macro_rules! rainbow_segment {
     };
 }
 
+/// Resolve the directory the prompt should display.
+///
+/// When `resolve_symlinks` is set we always use the real (symlink-resolved)
+/// cwd. Otherwise we prefer the shell's logical `$PWD`, which preserves
+/// symlinks - but only off Windows. On Windows `$PWD` is either unset
+/// (cmd / PowerShell) or an MSYS-style POSIX path such as `/c/Users/alex` under
+/// Git Bash. A native Windows binary uses `\` as its path separator, so it
+/// can't split or home-contract a forward-slash `$PWD`: the whole path becomes
+/// a single unsplittable segment that the leading `skip(1)` then discards,
+/// leaving the module empty. So on Windows we always fall back to the real cwd,
+/// which yields a proper `C:\...` path.
+fn resolve_cwd(
+    resolve_symlinks: bool,
+    windows: bool,
+    pwd: Option<OsString>,
+    current_dir: impl FnOnce() -> PathBuf,
+) -> PathBuf {
+    if resolve_symlinks || windows {
+        return current_dir();
+    }
+    pwd.map(PathBuf::from).unwrap_or_else(current_dir)
+}
+
 impl<S: CwdScheme> Module for Cwd<S> {
     fn append_segments(&mut self, powerline: &mut Powerline) {
-        let current_dir = if self.resolve_symlinks {
-            env::current_dir().unwrap()
-        } else {
-            // $PWD is the shell's logical (symlink-preserving) cwd, but it isn't
-            // set on Windows or by every shell, so fall back to the real cwd.
-            env::var_os("PWD")
-                .map(path::PathBuf::from)
-                .unwrap_or_else(|| env::current_dir().unwrap())
-        };
+        let current_dir = resolve_cwd(
+            self.resolve_symlinks,
+            cfg!(windows),
+            env::var_os("PWD"),
+            || env::current_dir().unwrap(),
+        );
 
         let current_dir = current_dir.to_string_lossy();
         let mut cwd: &str = &current_dir;
@@ -98,5 +119,48 @@ impl<S: CwdScheme> Module for Cwd<S> {
                 rainbow_segment!(powerline, current_bg, val);
             }
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn never_called() -> PathBuf {
+        panic!("current_dir should not have been called");
+    }
+
+    #[test]
+    fn prefers_pwd_off_windows() {
+        let dir = resolve_cwd(false, false, Some(OsString::from("/home/alex/src")), never_called);
+        assert_eq!(dir, PathBuf::from("/home/alex/src"));
+    }
+
+    #[test]
+    fn falls_back_to_current_dir_when_pwd_unset_off_windows() {
+        let dir = resolve_cwd(false, false, None, || PathBuf::from("/home/alex/src"));
+        assert_eq!(dir, PathBuf::from("/home/alex/src"));
+    }
+
+    #[test]
+    fn ignores_msys_pwd_on_windows() {
+        // Git Bash sets `$PWD` to a forward-slash POSIX path; a native Windows
+        // binary must ignore it and use the real cwd, otherwise the module
+        // renders empty (regression test).
+        let dir = resolve_cwd(
+            false,
+            true,
+            Some(OsString::from("/c/Users/alex/src")),
+            || PathBuf::from(r"C:\Users\alex\src"),
+        );
+        assert_eq!(dir, PathBuf::from(r"C:\Users\alex\src"));
+    }
+
+    #[test]
+    fn resolve_symlinks_always_uses_current_dir() {
+        let dir = resolve_cwd(true, false, Some(OsString::from("/logical/pwd")), || {
+            PathBuf::from("/real/cwd")
+        });
+        assert_eq!(dir, PathBuf::from("/real/cwd"));
     }
 }

--- a/src/modules/cwd.rs
+++ b/src/modules/cwd.rs
@@ -1,7 +1,7 @@
+use std::env;
 use std::ffi::OsString;
 use std::marker::PhantomData;
 use std::path::{PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
-use std::env;
 
 use crate::colors::Color;
 use crate::platform;
@@ -132,7 +132,12 @@ mod tests {
 
     #[test]
     fn prefers_pwd_off_windows() {
-        let dir = resolve_cwd(false, false, Some(OsString::from("/home/alex/src")), never_called);
+        let dir = resolve_cwd(
+            false,
+            false,
+            Some(OsString::from("/home/alex/src")),
+            never_called,
+        );
         assert_eq!(dir, PathBuf::from("/home/alex/src"));
     }
 


### PR DESCRIPTION
## Problem
The `current dir` module renders **empty** under Git Bash on Windows (works fine on macOS/Linux, and under cmd/PowerShell).

## Root cause
`superline` is a native Windows binary, so `MAIN_SEPARATOR` is `\`. With the default `resolve_symlinks: false`, the module reads `$PWD`. Git Bash sets `$PWD` to an MSYS-style POSIX path like `/c/Users/alex/src` (forward slashes). The code then runs `cwd.split(MAIN_SEPARATOR /* '\' */).skip(1)` — since the path has no backslashes, `split` yields a single element and `.skip(1)` discards it, so nothing is appended. Home contraction also never matches (`C:\Users\alex` isn't a prefix of `/c/...`).

cmd/PowerShell are unaffected because they don't set `$PWD` (it already falls back to the real cwd).

## Fix
Extracted a pure, tested `resolve_cwd()` helper that ignores `$PWD` on Windows and always uses `env::current_dir()`, which returns a proper `C:\...` path that splits and home-contracts correctly. Unix behaviour (preferring the symlink-preserving `$PWD`) is unchanged.

## Tests
Added 4 unit tests, including a regression test for the MSYS `$PWD` case. Full suite + clippy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)