### PR TITLE
fix(pr): wrap OSC 8 hyperlink in shell non-printing markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent notes for superline
+
+## CHANGELOG.md is generated — do not edit it
+
+`CHANGELOG.md` is maintained automatically (release tooling derives it from the
+Conventional Commit messages on merged PRs). Never hand-edit it in a PR.
+
+To make something show up in the changelog, write a proper Conventional Commit
+instead (e.g. `fix(pr): ...`, `feat(git): ...`) — the entry is generated from
+that at release time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   visible columns, corrupting cursor tracking and smearing the powerline glyph
   colours on redraw. For bash, ESC is now spelled `\e` and the ST terminator's
   backslash as `\\` so it doesn't merge with the `\]` close marker. fish and
-  PowerShell were unaffected.
+  PowerShell were unaffected. ([#28](https://github.com/alxhill/superline/pull/28))
 
 ## [0.5.4](https://github.com/alxhill/superline/compare/v0.5.3...v0.5.4) - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(pr)* wrap the PR segment's OSC 8 hyperlink in each shell's non-printing
+  markers (`\[ \]` for bash, `%{ %}` for zsh). The hyperlink escapes were always
+  emitted raw, so bash readline counted them - and the entire PR URL - as
+  visible columns, corrupting cursor tracking and smearing the powerline glyph
+  colours on redraw. For bash, ESC is now spelled `\e` and the ST terminator's
+  backslash as `\\` so it doesn't merge with the `\]` close marker. fish and
+  PowerShell were unaffected.
+
 ## [0.5.4](https://github.com/alxhill/superline/compare/v0.5.3...v0.5.4) - 2026-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- *(pr)* wrap the PR segment's OSC 8 hyperlink in each shell's non-printing
-  markers (`\[ \]` for bash, `%{ %}` for zsh). The hyperlink escapes were always
-  emitted raw, so bash readline counted them - and the entire PR URL - as
-  visible columns, corrupting cursor tracking and smearing the powerline glyph
-  colours on redraw. For bash, ESC is now spelled `\e` and the ST terminator's
-  backslash as `\\` so it doesn't merge with the `\]` close marker. fish and
-  PowerShell were unaffected. ([#28](https://github.com/alxhill/superline/pull/28))
-
 ## [0.5.4](https://github.com/alxhill/superline/compare/v0.5.3...v0.5.4) - 2026-06-23
 
 ### Added

--- a/src/powerline.rs
+++ b/src/powerline.rs
@@ -304,7 +304,10 @@ impl Powerline {
         marker: Option<(&str, Color)>,
     ) {
         let mut visible_width = label.chars().count();
-        let link = format!("\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\", url, label);
+        // The OSC 8 open/close escapes are invisible, so wrap them in the
+        // shell's non-printing markers; only `label` between them is printing.
+        let (open, close) = hyperlink(url);
+        let link = format!("{open}{label}{close}");
         let seg = match marker {
             Some((glyph, color)) => {
                 // separating space + the glyph itself

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -25,6 +25,41 @@ impl FgColor {
     }
 }
 
+/// The OSC 8 hyperlink open (`ESC ]8;;<url> ST`) and close (`ESC ]8;; ST`)
+/// sequences for the active shell, wrapped so the line editor treats them as
+/// zero-width.
+///
+/// `BgColor`/`FgColor`/`Reset` already wrap themselves, but the hyperlink built
+/// in `add_hyperlink_segment` bypasses them. Without the markers, bash readline
+/// and zsh count the escapes - and the whole URL - as visible columns, which
+/// corrupts cursor tracking so the prompt smears on redraw (fish/pwsh handle
+/// raw escapes themselves and need no markers).
+///
+/// Bash needs more than wrapping: it must use readline's `\e` spelling for ESC
+/// (a raw ESC works for the terminal but the project escapes everything as
+/// `\e`), and the literal backslash of the ST terminator must be `\\` - a raw
+/// `\` sitting right before the `\]` close marker would be decoded as the pair
+/// `\\` (a literal backslash), leaving the `\[` region unterminated.
+pub fn hyperlink(url: &str) -> (String, String) {
+    hyperlink_for(SHELL.get().expect("shell not specified!"), url)
+}
+
+/// Pure resolver behind [`hyperlink`], split out so the per-shell escaping can
+/// be tested without the process-global `SHELL` (which is set only once).
+fn hyperlink_for(shell: &Shell, url: &str) -> (String, String) {
+    match shell {
+        Shell::Bash => (
+            format!(r"\[\e]8;;{url}\e\\\]"),
+            r"\[\e]8;;\e\\\]".to_string(),
+        ),
+        Shell::Bare => (format!("\x1b]8;;{url}\x1b\\"), "\x1b]8;;\x1b\\".to_string()),
+        Shell::Zsh => (
+            format!("%{{\x1b]8;;{url}\x1b\\%}}"),
+            "%{\x1b]8;;\x1b\\%}".to_string(),
+        ),
+    }
+}
+
 impl From<Color> for FgColor {
     fn from(c: Color) -> Self {
         FgColor(c.0)
@@ -70,5 +105,40 @@ impl std::fmt::Display for Reset {
             Shell::Bare => f.write_str("\x1b[0m"),
             Shell::Zsh => f.write_str("%{\x1b[39m%}%{\x1b[49m%}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const URL: &str = "https://example.com/pr/1";
+
+    #[test]
+    fn bash_hyperlink_uses_readline_markers_and_no_raw_escapes() {
+        let (open, close) = hyperlink_for(&Shell::Bash, URL);
+        // The non-printing markers must balance, ESC must be spelled `\e` (no
+        // raw byte), and the ST's backslash must be `\\` so it doesn't merge
+        // with the `\]` close marker and leave the region unterminated.
+        assert_eq!(open, r"\[\e]8;;https://example.com/pr/1\e\\\]");
+        assert_eq!(close, r"\[\e]8;;\e\\\]");
+        for s in [&open, &close] {
+            assert!(s.starts_with(r"\[") && s.ends_with(r"\]"));
+            assert!(!s.contains('\x1b'), "bash must not emit a raw ESC byte");
+        }
+    }
+
+    #[test]
+    fn zsh_hyperlink_wraps_raw_escapes_in_percent_markers() {
+        let (open, close) = hyperlink_for(&Shell::Zsh, URL);
+        assert_eq!(open, "%{\x1b]8;;https://example.com/pr/1\x1b\\%}");
+        assert_eq!(close, "%{\x1b]8;;\x1b\\%}");
+    }
+
+    #[test]
+    fn bare_hyperlink_is_unwrapped_raw_osc8() {
+        let (open, close) = hyperlink_for(&Shell::Bare, URL);
+        assert_eq!(open, "\x1b]8;;https://example.com/pr/1\x1b\\");
+        assert_eq!(close, "\x1b]8;;\x1b\\");
     }
 }


### PR DESCRIPTION
## Problem
In **bash**, the powerline glyph colours in the prompt render garbled / smeared (PowerShell and fish are fine). It's most visible once the **PR segment** is present, and gets worse as you type (on line redraw).

## Root cause
The PR segment renders its number as an [OSC 8 terminal hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda). Every colour/reset escape in the prompt is wrapped in the shell's non-printing markers so the line editor can compute the prompt width — `\[ \]` for bash, `%{ %}` for zsh — but the hyperlink escapes were emitted **raw** for every shell:

```rust
let link = format!("\x1b]8;;{}\x1b\{}\x1b]8;;\x1b\\", url, label);
```

So bash's readline counted the OSC sequences **and the entire PR URL** as visible columns. That corrupts its width/cursor tracking, and on every redraw the prompt smears — manifesting as garbled powerline glyph colours. fish/PowerShell emit bare escapes and let their line editors parse OSC themselves, so they were unaffected.

## Fix
Build the open/close hyperlink sequences per shell via a new `terminal::hyperlink` helper (alongside the existing `BgColor`/`FgColor`/`Reset` shell logic): `\[ \]` for bash, `%{ %}` for zsh, bare for fish/pwsh.

Bash needs two extra details, both verified by the byte-level output:
- ESC is spelled `\e` (matching the rest of the prompt — no raw ESC byte), and
- the ST terminator's backslash is written `\`. A raw `\` sitting immediately before the `\]` close marker would decode as the pair `\` (a literal backslash), leaving the `\[` region **unterminated**.

## Tests
Split into a pure `hyperlink_for(shell, url)` (the `SHELL` global can only be set once per process) and added unit tests pinning the exact per-shell output, including the bash "balanced markers / no raw ESC / `\` before `\]`" invariants. Full suite + clippy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)